### PR TITLE
Make the font bigger in the login screen input boxes

### DIFF
--- a/public/login/style.css
+++ b/public/login/style.css
@@ -27,6 +27,7 @@ input {
   border-color: #CCCCCC;
   border-radius: 4px;
   width: 100%;
+  font-size: 1em;
 }
 .btn {
   background-color: #337AB7;


### PR DESCRIPTION
Text in the input fields is really small on:
* medic-android
* chrome
* firefox

This PR should make text the same size as for the text labels.