### PR TITLE
Automatic DDoc extraction #36

### DIFF
--- a/ddoc-extraction.js
+++ b/ddoc-extraction.js
@@ -1,0 +1,90 @@
+var db = require('./db'),
+    async = require('async'),
+    _ = require('underscore');
+
+var getMasterDdoc = function(callback) {
+  db.medic.get('_design/medic', function(err, ddoc) {
+    // explitly call the callback with just these two params. Couch passes more
+    // params to the callback, and we don't want those feeding into async.waterfall
+    callback(err, ddoc);
+  });
+};
+
+var extractDdocs = function(ddoc, callback) {
+  var attachmentNames = Object.keys(ddoc._attachments).filter(function(name) {
+    return name.startsWith('ddocs/compiled/');
+  });
+
+  console.log('Found ' + attachmentNames.length + ' attached ddocs');
+
+  callback(null, ddoc._rev, attachmentNames);
+};
+
+var ddocNameFromAttachmentName = function(attachmentName) {
+  return '_design/' + /ddocs\/compiled\/(.+)\.json/.exec(attachmentName)[1];
+};
+
+var updateIfRequired = function(masterRevision, attachmentName, callback) {
+  var ddocName = ddocNameFromAttachmentName(attachmentName);
+
+  console.log('Looking at', attachmentName);
+
+  db.medic.get(ddocName, function(ddocErr, ddoc) {
+    if (ddocErr && ddocErr.error !== 'not_found') {
+      callback(ddocErr);
+    } else {
+      db.medic.get('_design/medic/'+attachmentName, function(attachErr, attachedDdoc) {
+        if (attachErr) {
+          callback(attachErr);
+        } {
+          if (ddocErr && ddocErr.error === 'not_found') {
+            console.log(ddocName + ' is new, uploading');
+
+            attachedDdoc.parentRev = masterRevision;
+            db.medic.insert(attachedDdoc, callback);
+          } else if (ddoc && ddoc.parentRev !== masterRevision) {
+            console.log(ddocName + ' may have changed, uploading');
+
+            attachedDdoc._rev = ddoc._rev;
+            attachedDdoc.parentRev = masterRevision;
+            db.medic.insert(attachedDdoc, callback);
+          } else {
+            console.log(ddocName + ' has not changed');
+            callback();
+          }
+        }
+      });
+    }
+  });
+};
+
+module.exports = {
+  run: function(runComplete) {
+    console.log('Extracting ddocs…');
+
+    async.waterfall([
+        getMasterDdoc,
+        extractDdocs,
+        function(masterRevision, attachmentNames, callback) {
+          async.each(
+            attachmentNames,
+            _.partial(updateIfRequired, masterRevision),
+            callback);
+        }
+      ], function(err) {
+        if (err) {
+          console.log('Something went wrong trying to extract ddocs', err, console.trace());
+        } else {
+          console.log('…Done');
+        }
+        runComplete(err);
+      });
+  }
+};
+
+if (process.env.TEST_ENV) {
+  _.extend(module.exports, {
+    ddocNameFromAttachmentName: ddocNameFromAttachmentName,
+    extractDdocs: extractDdocs,
+  });
+}

--- a/ddoc-extraction.js
+++ b/ddoc-extraction.js
@@ -22,7 +22,8 @@ var extractDdocs = function(ddoc, callback) {
 };
 
 var ddocNameFromAttachmentName = function(attachmentName) {
-  return '_design/' + /ddocs\/compiled\/(.+)\.json/.exec(attachmentName)[1];
+  var designDocNameFromFilePath = /ddocs\/compiled\/(.+)\.json/;
+  return '_design/' + designDocNameFromFilePath.exec(attachmentName)[1];
 };
 
 var updateIfRequired = function(masterRevision, attachmentName, callback) {

--- a/ddoc-extraction.js
+++ b/ddoc-extraction.js
@@ -12,7 +12,8 @@ var getMasterDdoc = function(callback) {
 
 var extractDdocs = function(ddoc, callback) {
   var attachmentNames = Object.keys(ddoc._attachments).filter(function(name) {
-    return name.startsWith('ddocs/compiled/');
+    // return name.startsWith('ddocs/compiled/'); // for nodejs > 0.12
+    return name.indexOf('ddocs/compiled/') === 0;
   });
 
   console.log('Found ' + attachmentNames.length + ' attached ddocs');

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ var _ = require('underscore'),
     scheduler = require('./scheduler'),
     AuditProxy = require('./audit-proxy'),
     migrations = require('./migrations'),
+    ddocExtraction = require('./ddoc-extraction'),
     translations = require('./translations'),
     target = 'http://' + db.settings.host + ':' + db.settings.port,
     proxy = require('http-proxy').createProxyServer({ target: target }),
@@ -455,6 +456,14 @@ migrations.run(function(err) {
     console.error(err);
   } else {
     console.log('Database migrations completed successfully');
+  }
+});
+
+ddocExtraction.run(function(err) {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log('Ddoc extraction completed successfully');
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -463,7 +463,7 @@ ddocExtraction.run(function(err) {
   if (err) {
     console.error(err);
   } else {
-    console.log('Ddoc extraction completed successfully');
+    console.log('DDoc extraction completed successfully');
   }
 });
 

--- a/tests/ddoc-extraction.js
+++ b/tests/ddoc-extraction.js
@@ -1,0 +1,118 @@
+var ddocExtraction = require('../ddoc-extraction'),
+    sinon = require('sinon'),
+    utils = require('./utils'),
+    db = require('../db');
+
+exports['ddocNameFromAttachmentName works'] = function(test) {
+  test.expect(1);
+  test.equal(
+    ddocExtraction.ddocNameFromAttachmentName('ddocs/compiled/erlang_filters.json'),
+    '_design/erlang_filters');
+  test.done();
+};
+
+exports['extractDdocs finds attached ddoc names'] = function(test) {
+  test.expect(1);
+
+  ddocExtraction.extractDdocs({
+    _rev: 'test-123',
+    _attachments: {
+      'foo': {},
+      'bar': {},
+      'ddocs/compiled/erlang_filters.json': {},
+    }
+  }, function(err, masterRevision, attachmentNames) {
+    test.deepEqual(attachmentNames, ['ddocs/compiled/erlang_filters.json']);
+    test.done();
+  });
+};
+
+var testMasterDdoc = {
+  _id: '_design/medic',
+  _rev: '1-testMasterDdocRev',
+  _attachments: {
+    'foo': {},
+    'bar': {},
+    'ddocs/compiled/something_old.json': {},
+    'ddocs/compiled/something_stale.json': {},
+    'ddocs/compiled/something_new.json': {}
+  }
+};
+
+var somethingOldAttachment = {
+  _id: '_design/something_old'
+};
+var somethingStaleAttachment = {
+  _id: '_design/something_stale'
+};
+var somethingNewAttachment = {
+  _id: '_design/something_new'
+};
+
+var somethingOldDdoc = {
+  _id: '_design/something_old',
+  parentRev: '1-testMasterDdocRev'
+};
+
+var somethingStaleDdoc = {
+  _id: '_design/something_stale',
+  parentRev: '1-testMasterDdocRevOld'
+};
+
+exports.tearDown = function (callback) {
+  utils.restore(db.medic.get);
+  callback();
+};
+
+exports['run finds all attached ddocs and, if required, updates them'] = function(test) {
+  test.expect(9);
+
+  var wrappedGet = sinon.stub(db.medic, 'get');
+
+  var getDdoc = wrappedGet.withArgs('_design/medic').callsArgWith(1, null, testMasterDdoc, {});
+  var getSomethingOldAttachment = wrappedGet.withArgs('_design/medic/ddocs/compiled/something_old.json').callsArgWith(1, null, somethingOldAttachment);
+  var getSomethingStaleAttachment = wrappedGet.withArgs('_design/medic/ddocs/compiled/something_stale.json').callsArgWith(1, null, somethingStaleAttachment);
+  var getSomethingNewAttachment = wrappedGet.withArgs('_design/medic/ddocs/compiled/something_new.json').callsArgWith(1, null, somethingNewAttachment);
+  var getSomethingOldDdoc = wrappedGet.withArgs('_design/something_old').callsArgWith(1, null, somethingOldDdoc);
+  var getSomethingStaleDdoc = wrappedGet.withArgs('_design/something_stale').callsArgWith(1, null, somethingStaleDdoc);
+  var getSomethingNewDdoc = wrappedGet.withArgs('_design/something_new').callsArgWith(1, {error: 'not_found'});
+
+  var wrappedInsert = sinon.stub(db.medic, 'insert').callsArg(1);
+
+  ddocExtraction.run(function(err) {
+    test.ok(!err);
+
+    test.equals(getDdoc.callCount, 1);
+    test.equals(getSomethingOldAttachment.callCount, 1);
+    test.equals(getSomethingStaleAttachment.callCount, 1);
+    test.equals(getSomethingNewAttachment.callCount, 1);
+    test.equals(getSomethingOldDdoc.callCount, 1);
+    test.equals(getSomethingStaleDdoc.callCount, 1);
+    test.equals(getSomethingNewDdoc.callCount, 1);
+
+    test.equals(wrappedInsert.callCount, 2);
+
+    test.done();
+  });
+};
+
+exports['works when there are no attached ddocs'] = function(test) {
+  test.expect(2);
+
+  var wrappedGet = sinon.stub(db.medic, 'get');
+
+  wrappedGet.withArgs('_design/medic').callsArgWith(1, null, {
+    _id: '_design/medic',
+    _rev: '1-testMasterDdocRev',
+    _attachments: {
+      'foo': {},
+      'bar': {},
+    }});
+
+  ddocExtraction.run(function(err) {
+    test.ok(!err);
+
+    test.ok(wrappedGet.calledOnce);
+    test.done();
+  });
+};


### PR DESCRIPTION
This feature supports our ability to have muiltiple DDocs being served out of
the same Kanso project.

On the `medic-webapp` side, all extra Ddocs should be JSON files (with their
correct `_id` etc) inside the `ddocs/compiled` directory. This is then picked
up by Kanso as an attachment and pushed to Couch.

When `medic-api` runs it will run this code. This code looks through all
attached Ddocs, and re-uploads them if it thinks it should.