### PR TITLE
Simplify console.log call in server-utils

### DIFF
--- a/server-utils.js
+++ b/server-utils.js
@@ -31,8 +31,7 @@ module.exports = {
   },
 
   serverError: function(err, req, res) {
-    console.error('Server error: ');
-    console.log('  detail: ' + (err.stack || JSON.stringify(err)));
+    console.error('Server error:', err);
     res.writeHead(500, {
       'Content-Type': 'text/plain'
     });


### PR DESCRIPTION
1. doesn't make much sense to use `console.error` for the initial message and `console.log` for the details, as they may end up in different places.
2. having two separate calls may mean they're separated in the log file (perhaps not, with node?)
3. passing an `Error` to `console.(log|error)()` should end up giving us the stacktrace anyway