### PR TITLE
allow `reported_date` on places/people to use MS since Unix Epoch.

### DIFF
--- a/API_v1.md
+++ b/API_v1.md
@@ -8,6 +8,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
+- [Overview](#overview)
+  - [Timestamps](#timestamps)
 - [Export](#export)
   - [GET /api/v1/export/forms/{formcode}](#get-apiv1exportformsformcode)
   - [GET /api/v1/export/messages](#get-apiv1exportmessages)
@@ -38,6 +40,31 @@
   - [DELETE /api/v1/users/{{username}}](#delete-apiv1usersusername)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Overview
+
+## Timestamps
+
+Various properties throughout this API use a timestamp value, the
+following formats are supported:
+
+ - ISO 8601 combined date and time with timezone of the format below where "Z"
+   is offset from UTC like "-03", "+1245", or just "Z" which is UTC (0 offset);
+
+       YYYY-MM-DDTHH:mm:ssZ
+       YYYY-MM-DDTHH:mm:ss.SSSZ
+
+ - Milliseconds since Unix Epoch
+
+A compatible value can be generated using the `toISOString` or `toValue` method
+on a Javascript Date object.
+
+### Examples
+
+  - 2011-10-10T14:48:00-0300
+  - 2016-07-01T13:48:24+00:00
+  - 2016-07-01T13:48:24Z 
+  - 1467383343484 (MS since Epoch)
 
 # Export
 
@@ -297,7 +324,7 @@ allow multiple content types to appear in a single `Content-Type` header.
 | -------- | ----------------- |
 | message  | Message string in a supported format like Muvuku or Textforms.  Depending if your Medic Mobile instance is configured in forms-only mode or not you might recieve an error if the form is not found.  |
 | from |   Reporting phone number. |
-| reported_date |  Unix or Moment.js compatible timestamp of when the message was received on the gateway. Default: Date.now() |
+| reported_date |  Timestamp in MS since Unix Epoch of when the message was received on the gateway. Defaults to now. |
 | locale |  Optional locale string. |
   
 
@@ -312,7 +339,7 @@ All property names will be lowercased and any properties beginning with `_` (und
 | ----------- | ----------------- |
 | _meta.form  | The form code.    |
 | _meta.from  |  Reporting phone number. | 
-| _meta.reported_date |  Unix or Moment.js compatible timestamp of when the message was received on the gateway.  Default: now() |
+| _meta.reported_date |  Timestamp in MS since Unix Epoch of when the message was received on the gateway. Defaults to now. |
 | _meta.locale | Optional locale string.  Example: 'fr' |
     
 
@@ -597,7 +624,7 @@ Note: this does not accomodate having a `place` field on your form and will like
 | Key | Description       
 | -------- | -----------------
 | place | String that references a place or object that defines a new place. 
-| reported_date | Date string that is compatible with this format: "YYYY-MM-DDTHH:mm:ssZ".   Where "Z" is a timezone value like "-03" or "+1245".  Example: "2011-10-10T14:48:00-0300". If omitted the current time is used.  A compatible date string can be generated using the `toISOString` method on a Javascript Date object.
+| reported_date |  Timestamp of when the record was reported or created. Defaults to now.
 
 ## POST /api/v1/people
 
@@ -679,7 +706,7 @@ Use JSON in the request body to specify a place's details.
 | Key | Description       
 | -------- | -----------------
 | contact | String identifier for a person or object that defines a new person.
-| reported_date | Date string that is compatible with this format: "YYYY-MM-DDTHH:mm:ssZ".   Where "Z" is a timezone value like "-03" or "+1245".  Example: "2011-10-10T14:48:00-0300". If omitted the current time is used.  A compatible date string can be generated using the `toISOString` method on a Javascript Date object.
+| reported_date |  Timestamp of when the record was reported or created. Defaults to now.
 
 #### Place Types
 

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -6,16 +6,18 @@ var _ = require('underscore'),
     luceneConditionalLimit = 1000,
     noLmpDateModifier = 4;
 
+var tsFormats = [
+  'YYYY-MM-DDTHH:mm:ssZ',
+  'YYYY-MM-DDTHH:mm:ss.SSSZ', // native JS Date.toISOString format
+  'x' // ms since epoch (stored format)
+];
+
 var parseDate = function(str) {
-  return moment(str, 'YYYY-MM-DDTHH:mm:ssZ', true);
+  return moment(str, tsFormats, true);
 };
 
 var isDateStrValid = function(str) {
-  var formats = [
-    'YYYY-MM-DDTHH:mm:ssZ',
-    'YYYY-MM-DDTHH:mm:ss.SSSZ'
-  ];
-  return moment(str, formats, true).isValid();
+  return moment(str, tsFormats, true).isValid();
 };
 
 var formatDate = function(date) {

--- a/tests/controllers/people.js
+++ b/tests/controllers/people.js
@@ -125,6 +125,32 @@ exports['createPerson rejects invalid reported_date.'] = function(test) {
   });
 };
 
+exports['createPerson accepts valid reported_date in ms since epoch.'] = function(test) {
+  var person = {
+    name: 'Test',
+    reported_date: '123'
+  };
+  sinon.stub(places, 'getOrCreatePlace').callsArg(1);
+  sinon.stub(db.medic, 'insert', function(doc) {
+    test.ok(doc.reported_date === 123);
+    test.done();
+  });
+  controller.createPerson(person);
+};
+
+exports['createPerson accepts valid reported_date in string format'] = function(test) {
+  var person = {
+    name: 'Test',
+    reported_date: '2011-10-10T14:48:00-0300'
+  };
+  sinon.stub(places, 'getOrCreatePlace').callsArg(1);
+  sinon.stub(db.medic, 'insert', function(doc) {
+    test.ok(doc.reported_date === new Date('2011-10-10T14:48:00-0300').valueOf());
+    test.done();
+  });
+  controller.createPerson(person);
+};
+
 exports['createPerson sets a default reported_date.'] = function(test) {
   var person = {
     name: 'Test'

--- a/tests/controllers/places.js
+++ b/tests/controllers/places.js
@@ -286,6 +286,32 @@ exports['createPlaces rejects invalid reported_date.'] = function(test) {
   });
 };
 
+exports['createPlaces accepts valid reported_date in ms since epoch'] = function(test) {
+  var place = {
+    name: 'Test',
+    type: 'district_hospital',
+    reported_date: '123'
+  };
+  sinon.stub(db.medic, 'insert', function(doc) {
+    test.ok(doc.reported_date === 123);
+    test.done();
+  });
+  controller._createPlaces(place);
+};
+
+exports['createPlaces accepts valid reported_date in string format'] = function(test) {
+  var place = {
+    name: 'Test',
+    type: 'district_hospital',
+    reported_date: '2011-10-10T14:48:00-0300'
+  };
+  sinon.stub(db.medic, 'insert', function(doc) {
+    test.ok(doc.reported_date === new Date('2011-10-10T14:48:00-0300').valueOf());
+    test.done();
+  });
+  controller._createPlaces(place);
+};
+
 exports['createPlaces sets a default reported_date.'] = function(test) {
   var place = {
     name: 'Test',

--- a/tests/controllers/utils.js
+++ b/tests/controllers/utils.js
@@ -127,8 +127,28 @@ exports['getAllRegistrations generates multiple queries when over limit'] = func
 exports['describe isDateStrValid'] = function(test) {
   var tests = [
     {
-      // reject integers
-      val: 1234,
+      // reject object type
+      val: {},
+      res: false
+    },
+    {
+      // reject null type
+      val: null,
+      res: false
+    },
+    {
+      // reject undefined type
+      val: undefined,
+      res: false
+    },
+    {
+      // reject array type
+      val: [],
+      res: false
+    },
+    {
+      // reject empty string
+      val: '',
       res: false
     },
     {
@@ -139,6 +159,11 @@ exports['describe isDateStrValid'] = function(test) {
     {
       // reject badly formatted string
       val: 'Mar, 12 2001',
+      res: false
+    },
+    {
+      // reject incomplete string, use strict matching
+      val: '2011-10-10',
       res: false
     },
     {
@@ -159,6 +184,51 @@ exports['describe isDateStrValid'] = function(test) {
     {
       // accept 4 digit timezone
       val: '2011-10-10T14:48:00-0330',
+      res: true
+    },
+    {
+      // accept Z for UTC
+      val: '2011-10-10T14:48:00Z',
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: '0',
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: 0,
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: '123',
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: 123,
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: '1467383343484',
+      res: true
+    },
+    {
+      // accept ms since epoch
+      val: 1467383343484,
+      res: true
+    },
+    {
+      // accept output from native javascript method
+      val: new Date().valueOf(),
+      res: true
+    },
+    {
+      // accept output from native javascript method
+      val: '2016-07-01T14:58:26.336Z',
       res: true
     },
     {


### PR DESCRIPTION
This is also the stored format (ms since epoch) so we need to support it
in the validation anyway otherwise validating existing records will
fail.

Also added a bit of centralized documentation about timestamps.  The
other record types (Records) need to be updated still to support the new
format and that will get done soon.

https://github.com/medic/medic-webapp/issues/2449