### PR TITLE
Errors no longer error medic/medic-webapp#2520

### DIFF
--- a/migrations/extract-person-contacts.js
+++ b/migrations/extract-person-contacts.js
@@ -113,7 +113,7 @@ var createPerson = function(id, callback) {
   db.medic.get(id, function(err, facility) {
     if (err) {
       if (err.statusCode === 404) {
-        return callback(new Error('facility ' + facility._id + ' not found.'));
+        return callback(new Error('facility ' + id + ' not found.'));
       }
       return callback(err);
     }
@@ -246,7 +246,7 @@ var updateParents = function(id, callback) {
   db.medic.get(id, function(err, facility) {
     if (err) {
       if (err.statusCode === 404) {
-        return callback(new Error('facility ' + facility._id + ' not found.'));
+        return callback(new Error('facility ' + id + ' not found.'));
       }
       return callback(err);
     }


### PR DESCRIPTION
**HELLO REVIEWER,** I put this in a PR because I'm not sure on our stance on changing migrations once they're live. This seems like a strict upgrade, but I thought I'd check anyway.

This happened because the errors created attempt to reference the
object that failed to be loaded and caused the error to be created
in the first place.

(it's really hard to explain that concisely)