### PR TITLE
Streaming Exports

### DIFF
--- a/controllers/export-data.js
+++ b/controllers/export-data.js
@@ -449,53 +449,51 @@ var outputToCsv = function(options, tabs, callback) {
 };
 
 var outputToXml = function(options, tabs, callback) {
-  var chunkier = '';
-  var concat = function(chunk) {chunkier = chunkier + chunk;};
+  callback(null, function(write, done) {
+    var workbook = xmlbuilder.begin({ allowSurrogateChars: true, allowEmpty: true }, write)
+      .dec({ encoding: 'UTF-8' })
+      .ele('Workbook')
+      .att('xmlns', 'urn:schemas-microsoft-com:office:spreadsheet')
+      .att('xmlns:o', 'urn:schemas-microsoft-com:office:office')
+      .att('xmlns:x', 'urn:schemas-microsoft-com:office:excel')
+      .att('xmlns:html', 'http://www.w3.org/TR/REC-html140')
+      .att('xmlns:ss','urn:schemas-microsoft-com:office:spreadsheet')
+      .ins('mso-application', 'progid="Excel.Sheet"');
 
-  var workbook = xmlbuilder.begin({ allowSurrogateChars: true, allowEmpty: true }, concat)
-    .dec({ encoding: 'UTF-8' })
-    .ele('Workbook')
-    .att('xmlns', 'urn:schemas-microsoft-com:office:spreadsheet')
-    .att('xmlns:o', 'urn:schemas-microsoft-com:office:office')
-    .att('xmlns:x', 'urn:schemas-microsoft-com:office:excel')
-    .att('xmlns:html', 'http://www.w3.org/TR/REC-html140')
-    .att('xmlns:ss','urn:schemas-microsoft-com:office:spreadsheet')
-    .ins('mso-application', 'progid="Excel.Sheet"');
+    var row;
 
-  var row;
+    tabs.forEach(function(tab) {
+      var table = workbook
+        .ele('Worksheet', { 'ss:Name': tab.name })
+        .ele('Table');
 
-  tabs.forEach(function(tab) {
-    var table = workbook
-      .ele('Worksheet', { 'ss:Name': tab.name })
-      .ele('Table');
+      if (!options.skipHeader) {
+        row = table.ele('Row');
+        tab.columns.forEach(function(column) {
+          row.ele('Cell').ele('Data', {'ss:Type': 'String'}, column.label);
+          row.up().up();
+        });
+        row.up();
+      }
 
-    if (!options.skipHeader) {
-      row = table.ele('Row');
-      tab.columns.forEach(function(column) {
-        row.ele('Cell').ele('Data', {'ss:Type': 'String'}, column.label);
-        row.up().up();
+      tab.data.forEach(function(cells) {
+        row = table.ele('Row');
+        cells.forEach(function(cell) {
+          // passing '' as a value creates an opening and closing element: <Foo></Foo>
+          // passing nothing or undefined create one closed element: <Foo />
+          // Converting empty string to undefined to keep it consistent
+          row.ele('Cell').ele('Data', {'ss:Type': 'String'}, cell !== '' ? cell : undefined);
+          row.up().up();
+        });
+        row.up();
       });
-      row.up();
-    }
 
-    tab.data.forEach(function(cells) {
-      row = table.ele('Row');
-      cells.forEach(function(cell) {
-        // passing '' as a value creates an opening and closing element: <Foo></Foo>
-        // passing nothing or undefined create one closed element: <Foo />
-        // Converting empty string to undefined to keep it consistent
-        row.ele('Cell').ele('Data', {'ss:Type': 'String'}, cell !== '' ? cell : undefined);
-        row.up().up();
-      });
-      row.up();
+      table.up().up();
     });
 
-    table.up().up();
+    workbook.end();
+    done();
   });
-
-  workbook.end();
-
-  callback(null, chunkier);
 };
 
 var getRecordsFti = function(type, params, callback) {

--- a/server.js
+++ b/server.js
@@ -295,7 +295,7 @@ app.all([
 
       if (_.isFunction(exportDataResult)) {
         // wants to stream the result back
-        exportDataResult(res.write, res.end);
+        exportDataResult(res.write.bind(res), res.end.bind(res));
       } else {
         // has already generated result to return
         res.send(exportDataResult);

--- a/server.js
+++ b/server.js
@@ -280,18 +280,26 @@ app.all([
     req.query.type = req.params.type;
     req.query.form = req.params.form || req.query.form;
     req.query.district = ctx.district;
-    exportData.get(req.query, function(err, obj) {
+    exportData.get(req.query, function(err, exportDataResult) {
       if (err) {
         return serverUtils.serverError(err, req, res);
       }
+
       var format = formats[req.query.format] || formats.csv;
       var filename = req.params.type + '-' +
                      moment().format('YYYYMMDDHHmm') +
                      '.' + format.extension;
       res
         .set('Content-Type', format.contentType)
-        .set('Content-Disposition', 'attachment; filename=' + filename)
-        .send(obj);
+        .set('Content-Disposition', 'attachment; filename=' + filename);
+
+      if (_.isFunction(exportDataResult)) {
+        // wants to stream the result back
+        exportDataResult(res.write, res.end);
+      } else {
+        // has already generated result to return
+        res.send(exportDataResult);
+      }
     });
   });
 });
@@ -562,7 +570,7 @@ proxy.on('proxyReq', function(proxyReq, req, res) {
     // due to Chrome (including Android WebView) aggressively requesting
     // favicons on every page change and window.history update
     // (https://github.com/medic/medic-webapp/issues/1913 ), we have to stage an
-    // intervention: 
+    // intervention:
     writeHeaders(req, res, [
       [ 'Cache-Control', 'public, max-age=604800' ],
     ]);


### PR DESCRIPTION
Issue #2694

Exports now stream from API instead of being generated as one giant string, reducing memory requirements.

This is a POC that only converts `outputToXml`. It only streams XML generation, not pulling data from CouchDB. This would be the next natural step if we still get memory issues.

I'll work on converting the other output formats to stream as well.