### PR TITLE
Refining auditing hooks medic/medic-webapp#2895

### DIFF
--- a/server.js
+++ b/server.js
@@ -101,8 +101,7 @@ app.post(pathPrefix + 'login', jsonParser, login.post);
   pathPrefix + '_changes',
   // Interacting with mongo filters uses POST
   pathPrefix + '_find',
-  pathPrefix + '_explain',
-
+  pathPrefix + '_explain'
 ].forEach(function(url) {
   app.all(url, function(req, res) {
     proxy.web(req, res);

--- a/server.js
+++ b/server.js
@@ -94,6 +94,7 @@ app.post(pathPrefix + 'login', jsonParser, login.post);
   pathPrefix + '_revs_diff',
   pathPrefix + '_missing_revs',
   // Can use POST for specifiying ids
+  pathPrefix + '_bulk_get',
   pathPrefix + '_all_docs',
   pathPrefix + '_design/*/_list/**',
   pathPrefix + '_design/*/_show/**',


### PR DESCRIPTION
 - No trailing slash detection has been improved to include standard
   db path
 - All of the CouchDB API that uses POST but doesn't write (up to 2.0)
   is no longer audited