### PR TITLE
Fix migrations to associate records with contacts. medic/medic-webapp…

### DIFF
--- a/controllers/places.js
+++ b/controllers/places.js
@@ -5,7 +5,7 @@ var people = require('./people'),
     utils = require('./utils'),
     db = require('../db');
 
-var PLACE_EDITABLE_FIELDS = ['name', 'parent', 'contact'];
+var PLACE_EDITABLE_FIELDS = ['name', 'parent', 'contact', 'place_id'];
 
 var getPlace = function(id, callback) {
   db.medic.get(id, function(err, doc) {
@@ -152,7 +152,7 @@ var createPlaces = function(place, callback) {
  */
 var updateFields = function(place, data) {
   var ignore = [];
-  _.forEach(PLACE_EDITABLE_FIELDS , function(key) {
+  _.forEach(PLACE_EDITABLE_FIELDS, function(key) {
     if (!_.isUndefined(data[key]) && ignore.indexOf(key) === -1) {
       place[key] = data[key];
     }

--- a/migrations/associate-records-with-people.js
+++ b/migrations/associate-records-with-people.js
@@ -79,16 +79,12 @@ var migrateIncoming = function(doc, callback) {
     // already migrated
     return callback();
   }
-  var contactId = doc.related_entities &&
-      doc.related_entities.clinic &&
-      doc.related_entities.clinic.contact &&
-      doc.related_entities.clinic.contact._id;
-  if (!contactId) {
-    // no resolved entity
+  var clinic = doc.related_entities && doc.related_entities.clinic;
+  if (!clinic) {
     return callback();
   }
-  var clinicId = doc.related_entities.clinic._id;
-  getContact(contactId, clinicId, function(err, contact) {
+  var contactId = clinic.contact && clinic.contact._id;
+  getContact(contactId, clinic._id, function(err, contact) {
     if (err) {
       return callback(err);
     }

--- a/migrations/extract-person-contacts.js
+++ b/migrations/extract-person-contacts.js
@@ -81,34 +81,36 @@ var createPerson = function(id, callback) {
 
   // Create a new person doc to represent the contact.
   var createPerson = function(facilityId, oldContact, callback) {
-    people.createPerson(
-      {
-        name: oldContact.name,
-        phone: oldContact.phone,
-        place: facilityId
-      },
-      function(err, result) {
-        if (err) {
-          restoreContact(facilityId, oldContact, function() {
-            callback(new Error('Could not create person for facility ' + facilityId + ': ' + JSON.stringify(err, null, 2)));
-          });
-          return;
-        }
-        callback(null, result.id);
+    var person = {
+      name: oldContact.name,
+      phone: oldContact.phone,
+      place: facilityId
+    };
+    people.createPerson(person, function(err, result) {
+      if (err) {
+        restoreContact(facilityId, oldContact, function() {
+          callback(new Error('Could not create person for facility ' + facilityId + ': ' + JSON.stringify(err, null, 2)));
+        });
+        return;
+      }
+      callback(null, result.id);
     });
   };
 
   // Re-set the contact field in the facility : set it to the contents of the newly created `person` doc.
   var resetContact = function(facilityId, oldContact, personId, callback) {
-    places.updatePlace(facilityId, { contact: personId },
-      function(err) {
-        if (err) {
-          restoreContact(facilityId, oldContact, function() {
-            callback(new Error('Failed to update contact on facility ' + facilityId + ': ' + JSON.stringify(err, null, 2)));
-          });
-          return;
-        }
-        callback();
+    var updates = { contact: personId };
+    if (oldContact.rc_code) {
+      updates.place_id = oldContact.rc_code;
+    }
+    places.updatePlace(facilityId, updates, function(err) {
+      if (err) {
+        restoreContact(facilityId, oldContact, function() {
+          callback(new Error('Failed to update contact on facility ' + facilityId + ': ' + JSON.stringify(err, null, 2)));
+        });
+        return;
+      }
+      callback();
     });
   };
 

--- a/tests/integration/migrations/extract-person-contacts.js
+++ b/tests/integration/migrations/extract-person-contacts.js
@@ -64,6 +64,67 @@ describe('extract-person-contacts migration', function() {
     });
   });
 
+  it('should retain the rc code - #2970', function() {
+    // given
+    return utils.initDb([
+      {
+        _id: 'abc',
+        type: 'district_hospital',
+        name: 'myfacility',
+        contact: {
+          name: 'Alice',
+          phone: '+123',
+          rc_code: 'rc1'
+        },
+      },
+    ])
+    .then(function() {
+
+      // when
+      return utils.runMigration('extract-person-contacts');
+
+    })
+    .then(function() {
+
+      // expect
+      return utils.assertDb([
+        {
+          _id: 'abc',
+          type: 'district_hospital',
+          name: 'myfacility',
+          place_id: 'rc1',
+          contact: {
+            _id: ANY_STRING,
+            _rev: ANY_STRING,
+            type: 'person',
+            name: 'Alice',
+            phone: '+123',
+            reported_date: ANY_NUMBER,
+            parent: {
+              _id: 'abc',
+              _rev: ANY_STRING,
+              type: 'district_hospital',
+              name: 'myfacility',
+            },
+          },
+        },
+        {
+          name: 'Alice',
+          type: 'person',
+          phone: '+123',
+          reported_date: ANY_NUMBER,
+          parent: {
+            _id: 'abc',
+            _rev: ANY_STRING,
+            type: 'district_hospital',
+            name: 'myfacility',
+          },
+        },
+      ]);
+
+    });
+  });
+
   it('should not break if parent of contact not found', function() {
     // given
     return utils.initDb([

--- a/tests/unit/migrations/extract-person-contacts.js
+++ b/tests/unit/migrations/extract-person-contacts.js
@@ -188,10 +188,10 @@ exports['run updates contact and parent'] = function(test) {
 
   // Get doc for parent update
   getDoc.onCall(0).callsArgWith(1, null, {
-      _id: 'a',
-      contact: { name: 'name', 'phone': 'phone'},
-      parent: {_id: 'b', contact: { name: 'name1', 'phone': 'phone1' }}
-    });
+    _id: 'a',
+    contact: { name: 'name', 'phone': 'phone'},
+    parent: {_id: 'b', contact: { name: 'name1', 'phone': 'phone1' }}
+  });
   // Get parent doc
   getDoc.onCall(1).callsArgWith(1, null, { _id: 'b', contact: {}, newKey: 'newValue' });
   getDoc.onCall(2).callsArgWith(1, null, { _id: 'b', contact: {}, newKey: 'newValue' });
@@ -200,12 +200,11 @@ exports['run updates contact and parent'] = function(test) {
   // Update doc : update the parent field
   updatePlace.onCall(0).callsArgWith(2, null);
   // Get doc for contact update
-  getDoc.onCall(3).callsArgWith(1, null,
-    {
-      _id: 'a',
-      contact: { name: 'name', 'phone': 'phone'},
-      parent: { _id: 'b', contact: {_id: 'f'}}
-    });
+  getDoc.onCall(3).callsArgWith(1, null, {
+    _id: 'a',
+    contact: { name: 'name', phone: 'phone', rc_code: 'oldRcCode' },
+    parent: { _id: 'b', contact: {_id: 'f'}}
+  });
   // Update doc : deleted contact
   insertDoc.onCall(1).callsArgWith(1, null);
   // Create person doc
@@ -227,29 +226,30 @@ exports['run updates contact and parent'] = function(test) {
     test.equals(insertDoc.callCount, 2);
     test.equals(updatePlace.callCount, 2);
     // Parent was deleted, then reset.
-    test.deepEqual(insertDoc.firstCall.args[0],
-      {
-        _id: 'a',
-        contact: { name: 'name', phone: 'phone'},
-      });
+    test.deepEqual(insertDoc.firstCall.args[0], {
+      _id: 'a',
+      contact: { name: 'name', phone: 'phone'},
+    });
     test.equals(updatePlace.firstCall.args[0], 'a');
     test.deepEqual(updatePlace.firstCall.args[1], { parent: 'b'});
 
     // Contact was deleted, then reset.
-    test.deepEqual(insertDoc.secondCall.args[0],
-      {
-        _id: 'a',
-        parent: { _id: 'b', contact: {_id: 'f'}}
-      });
+    test.deepEqual(insertDoc.secondCall.args[0], {
+      _id: 'a',
+      parent: { _id: 'b', contact: {_id: 'f'}}
+    });
     test.equals(updatePlace.secondCall.args[0], 'a');
-    test.deepEqual(updatePlace.secondCall.args[1], { contact: 'c'});
+    test.deepEqual(updatePlace.secondCall.args[1], {
+      contact: 'c',
+      place_id: 'oldRcCode'
+    });
     // Contact created.
     test.equals(createPerson.callCount, 1);
     test.deepEqual(createPerson.firstCall.args[0], {
-        name: 'name',
-        phone: 'phone',
-        place: 'a'
-      });
+      name: 'name',
+      phone: 'phone',
+      place: 'a'
+    });
 
     test.done();
   });


### PR DESCRIPTION
…#2970

Fix the associate-records-with-people migration to not give up so easily - we can get the contact from the clinic id if necessary. Fix the extract-person-contacts migration to store the contact.rc_code in the place_id field instead of overwriting it altogether.