### PR TITLE
Add new message status for messages forwarded to gateway

### DIFF
--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -48,7 +48,7 @@ function markMessagesScheduled(messages, callback) {
   async.eachSeries(
     messages,
     function(message, callback) {
-      updateState(message.id, 'scheduled', null, callback);
+      updateState(message.id, 'forwarded-to-gateway', null, callback);
     },
     function(err) {
       if (err) {


### PR DESCRIPTION
The `sms-gateway` controller picks up all `pending` messages, and forwards these
to `medic-gateway`.  The controller then changes the messages' status to
`forwarded-to-gateway`.

Issue: #3047