### PR TITLE
Only redirect to login page if requesting client is human

### DIFF
--- a/client_is_human.js
+++ b/client_is_human.js
@@ -1,4 +1,4 @@
-var DALVIK_DETECT = new RegExp('^Dalvik/');
+const DALVIK_DETECT = new RegExp('^Dalvik/');
 
 /**
  * Check an incoming request to see if it's from a human browser, or from an
@@ -8,15 +8,15 @@ var DALVIK_DETECT = new RegExp('^Dalvik/');
  * N.B. medic-collect and ODK Collect do not always include a UA:
  * https://github.com/opendatakit/collect/issues/167
  */
-module.exports = function(req) {
-  var ua = req.headers && req.headers['user-agent'];
+module.exports = (req) => {
+  const ua = req.headers && req.headers['user-agent'];
 
   if (!ua) {
     return false;
   }
 
   if (DALVIK_DETECT.test(ua)) {
-    return ua.indexOf('medic.gateway') === -1;
+    return ua.includes('medic.gateway');
   }
 
   return true;

--- a/client_is_human.js
+++ b/client_is_human.js
@@ -16,7 +16,7 @@ module.exports = (req) => {
   }
 
   if (DALVIK_DETECT.test(ua)) {
-    return ua.includes('medic.gateway');
+    return !ua.includes('medic.gateway');
   }
 
   return true;

--- a/client_is_human.js
+++ b/client_is_human.js
@@ -1,0 +1,23 @@
+var DALVIK_DETECT = new RegExp('^Dalvik/');
+
+/**
+ * Check an incoming request to see if it's from a human browser, or from an
+ * app calling an API.  Err on the side of caution - if not sure, this function
+ * will assume it's a human.
+ *
+ * N.B. medic-collect and ODK Collect do not always include a UA:
+ * https://github.com/opendatakit/collect/issues/167
+ */
+module.exports = function(req) {
+  var ua = req.headers && req.headers['user-agent'];
+
+  if (!ua) {
+    return false;
+  }
+
+  if (DALVIK_DETECT.test(ua)) {
+    return ua.indexOf('medic.gateway') === -1;
+  }
+
+  return true;
+};

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ var _ = require('underscore'),
     db = require('./db'),
     config = require('./config'),
     auth = require('./auth'),
+    clientIsHuman = require('./client_is_human'),
     scheduler = require('./scheduler'),
     AuditProxy = require('./audit-proxy'),
     migrations = require('./migrations'),
@@ -556,7 +557,7 @@ var changesHander = _.partial(require('./handlers/changes').request, proxy);
 app.get(pathPrefix + '_changes', changesHander);
 app.post(pathPrefix + '_changes', jsonParser, changesHander);
 
-var writeHeaders = function(req, res, headers, redirect) {
+var writeHeaders = function(req, res, headers, redirectHumans) {
   res.oldWriteHead = res.writeHead;
   res.writeHead = function(_statusCode, _headers) {
     // hardcode this so we never show the basic auth prompt
@@ -566,8 +567,8 @@ var writeHeaders = function(req, res, headers, redirect) {
         res.setHeader(header[0], header[1]);
       });
     }
-    // for dynamic resources, redirect to login page
-    if (redirect && _statusCode === 401) {
+    // for dynamic resources, redirect humans to login page
+    if (_statusCode === 401 && redirectHumans && clientIsHuman(req)) {
       _statusCode = 302;
       res.setHeader(
         'Location',

--- a/tests/unit/client_is_human.js
+++ b/tests/unit/client_is_human.js
@@ -1,0 +1,82 @@
+var clientIsHuman = require('../../client_is_human');
+
+exports.setUp = function(callback) {
+  callback();
+};
+
+exports.tearDown = function (callback) {
+  callback();
+};
+
+exports['should return true for browser UserAgent strings'] = function(test) {
+  [
+    // Firefox (OSX)
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0',
+
+    // Android browser
+    'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+    'Mozilla/5.0 (Linux; Android 5.1.1; hi6210sft Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36',
+  ].forEach(function(humanUserAgent) {
+    // given
+    var req = mockRequestForUa(humanUserAgent);
+
+    // expect
+    test.equals(true, clientIsHuman(req));
+  });
+
+  // finally
+  test.done();
+};
+
+exports['should return false for gateway UserAgent strings'] = function(test) {
+  [
+    'Dalvik/2.1.0 (Linux; U; Android 5.1.1; hi6210sft Build/LMY47X) medic.gateway.alert.generic/SNAPSHOT',
+  ].forEach(function(humanUserAgent) {
+    // given
+    var req = mockRequestForUa(humanUserAgent);
+
+    // expect
+    test.equals(false, clientIsHuman(req));
+  });
+
+  // finally
+  test.done();
+};
+
+/**
+ * Interestingly, ODK Collect and medic-collect do not supply a User-Agent
+ * header with all requests.
+ */
+exports['should return false for collect UserAgent strings'] = function(test) {
+  // given
+  var req = mockRequestForUa(null);
+
+  // expect
+  test.equals(false, clientIsHuman(req));
+
+  // finally
+  test.done();
+};
+
+exports['should return true for medic-android UserAgent strings'] = function(test) {
+  [
+    'Dalvik/2.1.0 (Linux; U; Android 5.1.1; hi6210sft Build/LMY47X)',
+  ].forEach(function(humanUserAgent) {
+    // given
+    var req = mockRequestForUa(humanUserAgent);
+
+    // expect
+    test.equals(true, clientIsHuman(req));
+  });
+
+  // finally
+  test.done();
+};
+
+function mockRequestForUa(uaString) {
+  return {
+    headers: {
+      'user-agent': uaString,
+    },
+  };
+}

--- a/tests/unit/client_is_human.js
+++ b/tests/unit/client_is_human.js
@@ -1,14 +1,9 @@
-var clientIsHuman = require('../../client_is_human');
+const clientIsHuman = require('../../client_is_human');
 
-exports.setUp = function(callback) {
-  callback();
-};
+exports.setUp = (callback) => callback();
+exports.tearDown = (callback) => callback();
 
-exports.tearDown = function (callback) {
-  callback();
-};
-
-exports['should return true for browser UserAgent strings'] = function(test) {
+exports['should return true for browser UserAgent strings'] = (test) => {
   [
     // Firefox (OSX)
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:52.0) Gecko/20100101 Firefox/52.0',
@@ -16,9 +11,9 @@ exports['should return true for browser UserAgent strings'] = function(test) {
     // Android browser
     'Mozilla/5.0 (Linux; U; Android 4.0.3; ko-kr; LG-L160L Build/IML74K) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
     'Mozilla/5.0 (Linux; Android 5.1.1; hi6210sft Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36',
-  ].forEach(function(humanUserAgent) {
+  ].forEach((humanUserAgent) => {
     // given
-    var req = mockRequestForUa(humanUserAgent);
+    const req = mockRequestForUa(humanUserAgent);
 
     // expect
     test.equals(true, clientIsHuman(req));
@@ -28,12 +23,12 @@ exports['should return true for browser UserAgent strings'] = function(test) {
   test.done();
 };
 
-exports['should return false for gateway UserAgent strings'] = function(test) {
+exports['should return false for gateway UserAgent strings'] = (test) => {
   [
     'Dalvik/2.1.0 (Linux; U; Android 5.1.1; hi6210sft Build/LMY47X) medic.gateway.alert.generic/SNAPSHOT',
-  ].forEach(function(humanUserAgent) {
+  ].forEach((humanUserAgent) => {
     // given
-    var req = mockRequestForUa(humanUserAgent);
+    const req = mockRequestForUa(humanUserAgent);
 
     // expect
     test.equals(false, clientIsHuman(req));
@@ -47,9 +42,9 @@ exports['should return false for gateway UserAgent strings'] = function(test) {
  * Interestingly, ODK Collect and medic-collect do not supply a User-Agent
  * header with all requests.
  */
-exports['should return false for collect UserAgent strings'] = function(test) {
+exports['should return false for collect UserAgent strings'] = (test) => {
   // given
-  var req = mockRequestForUa(null);
+  const req = mockRequestForUa(null);
 
   // expect
   test.equals(false, clientIsHuman(req));
@@ -58,12 +53,12 @@ exports['should return false for collect UserAgent strings'] = function(test) {
   test.done();
 };
 
-exports['should return true for medic-android UserAgent strings'] = function(test) {
+exports['should return true for medic-android UserAgent strings'] = (test) => {
   [
     'Dalvik/2.1.0 (Linux; U; Android 5.1.1; hi6210sft Build/LMY47X)',
-  ].forEach(function(humanUserAgent) {
+  ].forEach((humanUserAgent) => {
     // given
-    var req = mockRequestForUa(humanUserAgent);
+    const req = mockRequestForUa(humanUserAgent);
 
     // expect
     test.equals(true, clientIsHuman(req));


### PR DESCRIPTION
This means that android apps like medic-collect and medic-gateway will receive
status code 401 instead of 302 when they fail to authenticate.

Issue: #3118

...because we all like parsing useragents.