### PR TITLE
Correctly concatenate request body

### DIFF
--- a/audit-proxy.js
+++ b/audit-proxy.js
@@ -79,7 +79,7 @@ AuditProxy.prototype.audit = function(proxy, req, res) {
     var endFn = function(cb) {
       var self = this;
       var options = { buffer: buffer };
-      var doc = parse(dataBuffer.join(''));
+      var doc = parse(Buffer.concat(dataBuffer).toString());
       audit(doc, function(err, data) {
         if (err) {
           return cb(err);

--- a/tests/unit/audit-proxy.js
+++ b/tests/unit/audit-proxy.js
@@ -40,7 +40,7 @@ exports['audit audits the request'] = function(test) {
   var passStreamFn = function(writeFn, endFn) {
     var chunks = JSON.stringify(doc).match(/.{1,4}/g);
     chunks.forEach(function(chunk){
-      writeFn(chunk, 'UTF-8', function() {});
+      writeFn(Buffer.from(chunk, 'utf8'), 'UTF-8', function() {});
     });
     endFn.call({push: function(body) {
       test.equals(body, JSON.stringify(auditedDoc));
@@ -83,7 +83,7 @@ exports['audit does not audit non json request'] = function(test) {
     web: function() {}
   };
   var passStreamFn = function(writeFn, endFn) {
-    writeFn(doc, 'UTF-8', function() {});
+    writeFn(Buffer.from(doc, 'utf8'), 'UTF-8', function() {});
     endFn.call({push: function(body) {
       test.equals(body, doc);
     }}, function() {});
@@ -122,7 +122,7 @@ exports['audit does not audit _local docs'] = function(test) {
     web: function() {}
   };
   var passStreamFn = function(writeFn, endFn) {
-    writeFn(doc, 'UTF-8', function() {});
+    writeFn(Buffer.from(doc, 'utf8'), 'UTF-8', function() {});
     endFn.call({push: function(body) {
       test.equals(body, doc);
     }}, function() {});
@@ -183,7 +183,7 @@ exports['audit audits the non _local docs'] = function(test) {
     }
   };
   var passStreamFn = function(writeFn, endFn) {
-    writeFn(JSON.stringify(docs), 'UTF-8', function() {});
+    writeFn(Buffer.from(JSON.stringify(docs), 'utf8'), 'UTF-8', function() {});
     endFn.call({push: function(body) {
       // pass through both local and proper
       test.equals(body, JSON.stringify(docs));
@@ -281,7 +281,7 @@ exports['audit emits errors when stream emits errors'] = function(test) {
           if (eventName === 'error') {
             var chunks = JSON.stringify(doc).match(/.{1,4}/g);
             chunks.forEach(function(chunk){
-              writeFn(chunk, 'UTF-8', function() {});
+              writeFn(Buffer.from(chunk, 'utf8'), 'UTF-8', function() {});
             });
             endFn.call({push: function(body) {
               test.equals(body, JSON.stringify(auditedDoc));


### PR DESCRIPTION
Joining the array of buffers serializes them individually so unicode
characters that cross the packet boundary are corrupted. Using the
Buffer.concat function combines them so the two halves of the
character are reunited before serialization.

medic/medic-webapp#3305