### PR TITLE
Migrate migration log to have predictable id

### DIFF
--- a/migrations.js
+++ b/migrations.js
@@ -3,33 +3,75 @@ var fs = require('fs'),
     async = require('async'),
     db = require('./db');
 
-var hasRun = function(meta, migration) {
-  if (!meta || !meta.migrations) {
+var MIGRATION_LOG_ID = 'migration-log',
+    MIGRATION_LOG_TYPE = 'meta';
+
+var hasRun = function(log, migration) {
+  if (!log || !log.migrations) {
     return false;
   }
-  return meta.migrations.indexOf(migration.name) !== -1;
+  return log.migrations.indexOf(migration.name) !== -1;
 };
 
 var error = function(migration, err) {
   return 'Migration "' + migration.name + '" failed with: ' + JSON.stringify(err);
 };
 
-var getMeta = function(callback) {
-  db.medic.view('medic-client', 'doc_by_type', { include_docs: true, key: [ 'meta' ] }, function(err, meta) {
+var getLogWithView = function(callback) {
+  var options = { include_docs: true, key: [ MIGRATION_LOG_TYPE ] };
+  db.medic.view('medic-client', 'doc_by_type', options, function(err, result) {
     if (err) {
       return callback(
         new Error(
           'Could not run migrations without doc_by_type view. Update ddoc. ' +
           JSON.stringify(err)));
     }
-    meta = meta && meta.rows && meta.rows[0] && meta.rows[0].doc;
-    if (!meta) {
-      meta = { type: 'meta' };
+    var log = result && result.rows && result.rows[0] && result.rows[0].doc;
+    callback(null, log);
+  });
+};
+
+var deleteOldLog = function(oldLog, callback) {
+  if (!oldLog) {
+    return callback();
+  }
+  oldLog._deleted = true;
+  db.medic.insert(oldLog, callback);
+};
+
+var createLog = function(callback) {
+  getLogWithView(function(err, oldLog) {
+    if (err) {
+      return callback(err);
     }
-    if (!meta.migrations) {
-      meta.migrations = [];
+    var newLog = {
+      _id: MIGRATION_LOG_ID,
+      type: MIGRATION_LOG_TYPE,
+      migrations: (oldLog && oldLog.migrations) || []
+    };
+    db.medic.insert(newLog, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      deleteOldLog(oldLog, function(err) {
+        if (err) {
+          return callback(err);
+        }
+        getLog(callback);
+      });
+    });
+  });
+};
+
+var getLog = function(callback) {
+  db.medic.get(MIGRATION_LOG_ID, function(err, doc) {
+    if (!err) {
+      return callback(null, doc);
     }
-    callback(null, meta);
+    if (err.statusCode === 404) {
+      return createLog(callback);
+    }
+    return callback(err);
   });
 };
 
@@ -46,12 +88,12 @@ var runMigration = function(migration, callback) {
     if (err) {
       return callback(error(migration, err));
     }
-    getMeta(function(err, meta) {
+    getLog(function(err, log) {
       if (err) {
         return callback(error(migration, err));
       }
-      meta.migrations.push(migration.name);
-      db.medic.insert(meta, function(err) {
+      log.migrations.push(migration.name);
+      db.medic.insert(log, function(err) {
         if (err) {
           return callback(error(migration, err));
         }
@@ -62,12 +104,12 @@ var runMigration = function(migration, callback) {
   });
 };
 
-var runMigrations = function(meta, migrations, callback) {
+var runMigrations = function(log, migrations, callback) {
   migrations.sort(sortMigrations);
   async.eachSeries(
     migrations,
     function(migration, callback) {
-      if (hasRun(meta, migration)) {
+      if (hasRun(log, migration)) {
         // already run
         return callback();
       }
@@ -79,15 +121,18 @@ var runMigrations = function(meta, migrations, callback) {
 
 module.exports = {
   run: function(callback) {
-    getMeta(function(err, meta) {
+    module.exports.get(function(err, migrations) {
       if (err) {
         return callback(err);
       }
-      module.exports.get(function(err, migrations) {
+      if (!migrations.length) {
+        return callback();
+      }
+      getLog(function(err, log) {
         if (err) {
           return callback(err);
         }
-        runMigrations(meta, migrations, callback);
+        runMigrations(log, migrations, callback);
       });
     });
   },

--- a/migrations.js
+++ b/migrations.js
@@ -39,7 +39,7 @@ var deleteOldLog = function(oldLog, callback) {
   db.medic.insert(oldLog, callback);
 };
 
-var createLog = function(callback) {
+var createMigrationLog = function(callback) {
   getLogWithView(function(err, oldLog) {
     if (err) {
       return callback(err);
@@ -65,13 +65,13 @@ var createLog = function(callback) {
 
 var getLog = function(callback) {
   db.medic.get(MIGRATION_LOG_ID, function(err, doc) {
-    if (!err) {
-      return callback(null, doc);
+    if (err) {
+      if (err.statusCode === 404) {
+        return createMigrationLog(callback);
+      }
+      return callback(err);
     }
-    if (err.statusCode === 404) {
-      return createLog(callback);
-    }
-    return callback(err);
+    callback(null, doc);
   });
 };
 
@@ -121,14 +121,11 @@ var runMigrations = function(log, migrations, callback) {
 
 module.exports = {
   run: function(callback) {
-    module.exports.get(function(err, migrations) {
+    getLog(function(err, log) {
       if (err) {
         return callback(err);
       }
-      if (!migrations.length) {
-        return callback();
-      }
-      getLog(function(err, log) {
+      module.exports.get(function(err, migrations) {
         if (err) {
           return callback(err);
         }

--- a/tests/unit/migrations.js
+++ b/tests/unit/migrations.js
@@ -8,16 +8,6 @@ exports.tearDown = function (callback) {
   callback();
 };
 
-exports['run does nothing if no migrations'] = function(test) {
-  var getLog = sinon.stub(db.medic, 'get').callsArgWith(1, null, { rows: [] });
-  sinon.stub(migrations, 'get').callsArgWith(0, null, []);
-  migrations.run(function(err) {
-    test.equals(err, undefined);
-    test.equals(getLog.callCount, 0);
-    test.done();
-  });
-};
-
 exports['run fails if migration does not have created date'] = function(test) {
   sinon.stub(db.medic, 'get').callsArgWith(1, null, {});
   sinon.stub(migrations, 'get').callsArgWith(0, null, [ { name: 'xyz' } ]);

--- a/tests/unit/migrations.js
+++ b/tests/unit/migrations.js
@@ -4,24 +4,22 @@ var sinon = require('sinon'),
     db = require('../../db');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.view, db.medic.insert, migrations.get);
+  utils.restore(db.medic.view, db.medic.get, db.medic.insert, migrations.get);
   callback();
 };
 
 exports['run does nothing if no migrations'] = function(test) {
-  test.expect(2);
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [] });
+  var getLog = sinon.stub(db.medic, 'get').callsArgWith(1, null, { rows: [] });
   sinon.stub(migrations, 'get').callsArgWith(0, null, []);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 1);
+    test.equals(getLog.callCount, 0);
     test.done();
   });
 };
 
 exports['run fails if migration does not have created date'] = function(test) {
-  test.expect(1);
-  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { migrations: [] } } ] });
+  sinon.stub(db.medic, 'get').callsArgWith(1, null, {});
   sinon.stub(migrations, 'get').callsArgWith(0, null, [ { name: 'xyz' } ]);
   migrations.run(function(err) {
     test.equals(err.message, 'Migration "xyz" has no "created" date property');
@@ -30,19 +28,18 @@ exports['run fails if migration does not have created date'] = function(test) {
 };
 
 exports['run does nothing if all migrations have run'] = function(test) {
-  test.expect(2);
-  var meta = { migrations: [ 'xyz' ] };
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: meta } ] });
+  var log = { migrations: [ 'xyz' ] };
+  var getLog = sinon.stub(db.medic, 'get').callsArgWith(1, null, log);
   sinon.stub(migrations, 'get').callsArgWith(0, null, [ { name: 'xyz' } ]);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 1);
+    test.equals(getLog.callCount, 1);
+    test.equals(getLog.args[0][0], 'migration-log');
     test.done();
   });
 };
 
 exports['executes migrations that have not run and updates meta'] = function(test) {
-  test.expect(5);
   var migration = [
     {
       name: 'xyz',
@@ -61,16 +58,16 @@ exports['executes migrations that have not run and updates meta'] = function(tes
       }
     }
   ];
-  var meta = { _id: 1, migrations: [ 'abc' ], type: 'meta' };
-  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: meta } ] });
+  var log = { _id: 'migration-log', migrations: [ 'abc' ], type: 'meta' };
+  var getLog = sinon.stub(db.medic, 'get').callsArgWith(1, null, log);
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 2);
+    test.equals(getLog.callCount, 2);
     test.equals(saveDoc.callCount, 1);
     test.deepEqual(saveDoc.firstCall.args[0], {
-      _id: 1,
+      _id: 'migration-log',
       migrations: [ 'abc', 'xyz' ],
       type: 'meta'
     });
@@ -79,7 +76,6 @@ exports['executes migrations that have not run and updates meta'] = function(tes
 };
 
 exports['executes multiple migrations that have not run and updates meta each time'] = function(test) {
-  test.expect(7);
   var migration = [
     {
       name: 'xyz',
@@ -98,23 +94,23 @@ exports['executes multiple migrations that have not run and updates meta each ti
       }
     }
   ];
-  var getView = sinon.stub(db.medic, 'view');
-  getView.onFirstCall().callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
-  getView.onSecondCall().callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
-  getView.onThirdCall().callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ 'xyz' ], type: 'meta' } } ] });
+  var getLog = sinon.stub(db.medic, 'get');
+  getLog.onCall(0).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
+  getLog.onCall(1).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
+  getLog.onCall(2).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ 'xyz' ] });
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 3);
+    test.equals(getLog.callCount, 3);
     test.equals(saveDoc.callCount, 2);
     test.deepEqual(saveDoc.firstCall.args[0], {
-      _id: 1,
+      _id: 'migration-log',
       migrations: [ 'xyz' ],
       type: 'meta'
     });
     test.deepEqual(saveDoc.secondCall.args[0], {
-      _id: 1,
+      _id: 'migration-log',
       migrations: [ 'xyz', 'abc' ],
       type: 'meta'
     });
@@ -123,7 +119,6 @@ exports['executes multiple migrations that have not run and updates meta each ti
 };
 
 exports['executes multiple migrations in order'] = function(test) {
-  test.expect(9);
   var migration = [
     {
       name: 'a',
@@ -150,26 +145,25 @@ exports['executes multiple migrations in order'] = function(test) {
       }
     }
   ];
-  var getView = sinon.stub(db.medic, 'view');
-  getView.onCall(0).callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
-  getView.onCall(1).callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
-  getView.onCall(2).callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ 'b' ], type: 'meta' } } ] });
-  getView.onCall(3).callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ 'b', 'a' ], type: 'meta' } } ] });
+  var getLog = sinon.stub(db.medic, 'get');
+  getLog.onCall(0).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
+  getLog.onCall(1).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
+  getLog.onCall(2).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ 'b' ] });
+  getLog.onCall(3).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ 'b', 'a' ] });
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 4);
+    test.equals(getLog.callCount, 4);
     test.equals(saveDoc.callCount, 3);
-    test.deepEqual(saveDoc.firstCall.args[0].migrations, [ 'b' ]);
-    test.deepEqual(saveDoc.secondCall.args[0].migrations, [ 'b', 'a' ]);
-    test.deepEqual(saveDoc.thirdCall.args[0].migrations, [ 'b', 'a', 'c' ]);
+    test.deepEqual(saveDoc.args[0][0].migrations, [ 'b' ]);
+    test.deepEqual(saveDoc.args[1][0].migrations, [ 'b', 'a' ]);
+    test.deepEqual(saveDoc.args[2][0].migrations, [ 'b', 'a', 'c' ]);
     test.done();
   });
 };
 
 exports['executes multiple migrations and stops when one errors'] = function(test) {
-  test.expect(6);
   var migration = [
     {
       name: 'a',
@@ -196,17 +190,17 @@ exports['executes multiple migrations and stops when one errors'] = function(tes
       }
     }
   ];
-  var getView = sinon.stub(db.medic, 'view');
-  getView.onFirstCall().callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
-  getView.onSecondCall().callsArgWith(3, null, { rows: [ { doc: { _id: 1, migrations: [ ], type: 'meta' } } ] });
+  var getLog = sinon.stub(db.medic, 'get');
+  getLog.onCall(0).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
+  getLog.onCall(1).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ ] });
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
     test.equals(err, 'Migration "b" failed with: "boom!"');
-    test.equals(getView.callCount, 2);
+    test.equals(getLog.callCount, 2);
     test.equals(saveDoc.callCount, 1);
     test.deepEqual(saveDoc.firstCall.args[0], {
-      _id: 1,
+      _id: 'migration-log',
       migrations: [ 'a' ],
       type: 'meta'
     });
@@ -214,28 +208,71 @@ exports['executes multiple migrations and stops when one errors'] = function(tes
   });
 };
 
-exports['creates meta if needed'] = function(test) {
-  test.expect(5);
-  var migration = [
-    {
-      name: 'xyz',
-      created: new Date(2015, 1, 1, 1, 0, 0, 0),
-      run: function(callback) {
-        test.ok(true);
-        callback();
-      }
+exports['creates log if needed'] = function(test) {
+  test.expect(6);
+  var migration = [{
+    name: 'xyz',
+    created: new Date(2015, 1, 1, 1, 0, 0, 0),
+    run: function(callback) {
+      test.ok(true);
+      callback();
     }
-  ];
+  }];
+  var getLog = sinon.stub(db.medic, 'get');
+  getLog.onCall(0).callsArgWith(1, { statusCode: 404 });
+  getLog.onCall(1).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [] });
+  getLog.onCall(2).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [] });
   var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ ] });
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
     test.equals(err, undefined);
-    test.equals(getView.callCount, 2);
-    test.equals(saveDoc.callCount, 1);
+    test.equals(getView.callCount, 1);
+    test.equals(saveDoc.callCount, 2);
     test.deepEqual(saveDoc.firstCall.args[0], {
+      _id: 'migration-log',
+      migrations: [ ],
+      type: 'meta'
+    });
+    test.deepEqual(saveDoc.secondCall.args[0], {
+      _id: 'migration-log',
       migrations: [ 'xyz' ],
       type: 'meta'
+    });
+    test.done();
+  });
+};
+
+exports['migrates meta to log'] = function(test) {
+  test.expect(5);
+  var migration = [{
+    name: 'xyz',
+    created: new Date(2015, 1, 1, 1, 0, 0, 0),
+    run: function() {
+      throw new Error('should not be called!');
+    }
+  }];
+  var oldLog = { _id: 1, type: 'meta', migrations: [ 'xyz' ] };
+  var getLog = sinon.stub(db.medic, 'get');
+  getLog.onCall(0).callsArgWith(1, { statusCode: 404 });
+  getLog.onCall(1).callsArgWith(1, null, { _id: 'migration-log', type: 'meta', migrations: [ 'xyz' ] });
+  var getView = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: oldLog } ] });
+  sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
+  var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
+  migrations.run(function(err) {
+    test.equals(err, undefined);
+    test.equals(getView.callCount, 1);
+    test.equals(saveDoc.callCount, 2);
+    test.deepEqual(saveDoc.firstCall.args[0], {
+      _id: 'migration-log',
+      migrations: [ 'xyz' ],
+      type: 'meta'
+    });
+    test.deepEqual(saveDoc.secondCall.args[0], {
+      _id: 1,
+      migrations: [ 'xyz' ],
+      type: 'meta',
+      _deleted: true
     });
     test.done();
   });


### PR DESCRIPTION
Make it easier to find the migration log as it turns out it's useful
information for humans as well as machines.

medic/medic-webapp#3294