### PR TITLE
Remove duplicate permission

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -102,14 +102,6 @@
       ]
     },
     {
-      "name": "can_view_analytics",
-      "roles": [
-        "national_admin",
-        "district_admin",
-        "analytics"
-      ]
-    },
-    {
       "name": "can_view_data_records",
       "roles": [
         "national_admin",
@@ -240,7 +232,8 @@
       "name": "can_view_analytics",
       "roles": [
         "national_admin",
-        "district_admin"
+        "district_admin",
+        "analytics"
       ]
     },
     {


### PR DESCRIPTION
The duplicate was loading into config fine, and potentially even working
fine, but was causing the permissions menu to fail to render, because
Angular did not like a repeater with the same name.

medic/medic-webapp#3251