### PR TITLE
Using sinon.sandbox for clearer, safer tests

### DIFF
--- a/tests/unit/auth.js
+++ b/tests/unit/auth.js
@@ -1,17 +1,12 @@
-var request = require('request'),
-    url = require('url'),
-    sinon = require('sinon'),
-    auth = require('../../auth'),
-    utils = require('./utils'),
-    config = require('../../config'),
-    db = require('../../db');
-
-exports.setUp = function(callback) {
-  callback();
-};
+const request = require('request'),
+      url = require('url'),
+      sinon = require('sinon').sandbox.create(),
+      auth = require('../../auth'),
+      config = require('../../config'),
+      db = require('../../db');
 
 exports.tearDown = function (callback) {
-  utils.restore(request.get, request.head, url.format, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/active-pregnancies.js
+++ b/tests/unit/controllers/active-pregnancies.js
@@ -1,8 +1,7 @@
 var controller = require('../../../controllers/active-pregnancies'),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.setUp = function(callback) {
   sinon.stub(config, 'get').returns({});
@@ -10,7 +9,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/delivery-location.js
+++ b/tests/unit/controllers/delivery-location.js
@@ -1,10 +1,9 @@
 var controller = require('../../../controllers/delivery-location'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.view);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/export-data.js
+++ b/tests/unit/controllers/export-data.js
@@ -4,8 +4,7 @@ var controller = require('../../../controllers/export-data'),
     fti = require('../../../controllers/fti'),
     childProcess = require('child_process'),
     JSZip = require('jszip'),
-    sinon = require('sinon'),
-    utils = require('../utils'),
+    sinon = require('sinon').sandbox.create(),
     moment = require('moment');
 
 function readStream(dataHook, callback) {
@@ -26,14 +25,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function(callback) {
-  utils.restore(
-    fti.get,
-    db.medic.view,
-    db.audit.list,
-    config.translate,
-    config.get,
-    childProcess.spawn
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/forms.js
+++ b/tests/unit/controllers/forms.js
@@ -2,16 +2,10 @@
 
 var controller = require('../../../controllers/forms'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.request,
-    db.sanitizeResponse,
-    db.medic.view,
-    db.medic.attachment.get
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/fti.js
+++ b/tests/unit/controllers/fti.js
@@ -1,15 +1,14 @@
 var controller = require('../../../controllers/fti'),
     utils = require('../../../controllers/utils'),
     config = require('../../../config'),
-    testUtils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.setUp = function(callback) {
   callback();
 };
 
 exports.tearDown = function (callback) {
-  testUtils.restore(utils.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/high-risk.js
+++ b/tests/unit/controllers/high-risk.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/high-risk'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function(callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 
@@ -100,7 +99,7 @@ exports['get returns all high risk pregnancies if no deliveries'] = function(tes
       { doc: { fields: { patient_id: 3 } } }
     ]
   });
-  
+
   // registrations
   fti.onCall(1).callsArgWith(2, null, {
     rows: [

--- a/tests/unit/controllers/login.js
+++ b/tests/unit/controllers/login.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/login'),
     _ = require('underscore'),
     db = require('../../../db'),
     auth = require('../../../auth'),
-    sinon = require('sinon'),
-    utils = require('../utils'),
+    sinon = require('sinon').sandbox.create(),
     config = require('../../../config'),
     request = require('request'),
     fs = require('fs'),
@@ -37,12 +36,7 @@ exports.setUp = function(callback) {
 
 exports.tearDown = function(callback) {
   db.settings = {};
-  utils.restore(
-    auth.getUserCtx,
-    fs.readFile,
-    config.translate,
-    request.post
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/message-utils.js
+++ b/tests/unit/controllers/message-utils.js
@@ -1,14 +1,9 @@
 var controller = require('../../../controllers/message-utils'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.medic.view,
-    db.medic.updateWithHandler,
-    controller.getMessage
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/missed-appointments.js
+++ b/tests/unit/controllers/missed-appointments.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/missed-appointments'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 
@@ -51,23 +50,23 @@ exports['get returns zero if all registrations have delivered'] = function(test)
   var fti = sinon.stub(db, 'fti');
   fti.onFirstCall().callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 1,
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 2,
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       }
     ]
   });
@@ -89,23 +88,23 @@ exports['get returns zero if all registrations have visits'] = function(test) {
   var fti = sinon.stub(db, 'fti');
   fti.onFirstCall().callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: '1',
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: '2',
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       }
     ]
   });
@@ -131,29 +130,29 @@ exports['get ignores registrations with no missed appointments'] = function(test
   var fti = sinon.stub(db, 'fti');
   fti.onFirstCall().callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 1,
           scheduled_tasks: []
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 2,
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(24, 'days').toISOString()
           } ]
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 3,
           scheduled_tasks: [ {
             group: 1,
             due: moment().subtract(11, 'days').toISOString()
           } ]
-        } 
+        }
       }
     ]
   });
@@ -172,8 +171,8 @@ exports['get returns all registrations with missed appointments'] = function(tes
   // get registrations
   fti.onCall(0).callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 1,
           fields: { patient_name: 'sarah' },
           form: 'R',
@@ -183,10 +182,10 @@ exports['get returns all registrations with missed appointments'] = function(tes
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 2,
           fields: { patient_name: 'sally' },
           form: 'P',
@@ -196,7 +195,7 @@ exports['get returns all registrations with missed appointments'] = function(tes
             group: 1,
             due: moment().subtract(20, 'days').toISOString()
           } ]
-        } 
+        }
       }
     ]
   });

--- a/tests/unit/controllers/missing-delivery-reports.js
+++ b/tests/unit/controllers/missing-delivery-reports.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/missing-delivery-reports'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 
@@ -61,7 +60,7 @@ exports['get returns zero if all registrations have delivered'] = function(test)
         }
       },
       {
-        doc: { 
+        doc: {
           patient_id: 2,
           scheduled_tasks: [ {
             group: 1,

--- a/tests/unit/controllers/monthly-deliveries.js
+++ b/tests/unit/controllers/monthly-deliveries.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/monthly-deliveries'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function(callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 
@@ -117,7 +116,7 @@ exports['get returns monthly deliveries count'] = function(test) {
       { month: 'Sep 1969', count: 1 }, // delivery report for patient 4
       { month: 'Oct 1969', count: 0 },
       { month: 'Nov 1969', count: 0 },
-      { month: 'Dec 1969', count: 0 } 
+      { month: 'Dec 1969', count: 0 }
     ];
     test.same(results, expected);
     test.equals(fti.callCount, 2);

--- a/tests/unit/controllers/monthly-registrations.js
+++ b/tests/unit/controllers/monthly-registrations.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/monthly-registrations'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -14,7 +13,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function(callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/people.js
+++ b/tests/unit/controllers/people.js
@@ -2,21 +2,12 @@ var controller = require('../../../controllers/people'),
     places = require('../../../controllers/places'),
     cutils = require('../../../controllers/utils'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var example;
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.medic.get,
-    db.medic.insert,
-    controller.getPerson,
-    controller.createPerson,
-    controller.validatePerson,
-    places.getOrCreatePlace,
-    cutils.isDateStrValid
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/places.js
+++ b/tests/unit/controllers/places.js
@@ -2,21 +2,12 @@ var controller = require('../../../controllers/places'),
     people = require('../../../controllers/people'),
     cutils = require('../../../controllers/utils'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var examplePlace;
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.medic.get,
-    db.medic.insert,
-    controller.getPlace,
-    controller._createPlace,
-    controller._validatePlace,
-    people.getOrCreatePerson,
-    cutils.isDateStrValid
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/record-utils.js
+++ b/tests/unit/controllers/record-utils.js
@@ -1,10 +1,9 @@
 var controller = require('../../../controllers/record-utils'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(db.request, db.getPath);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/records.js
+++ b/tests/unit/controllers/records.js
@@ -1,13 +1,9 @@
 var controller = require('../../../controllers/records'),
     recordUtils = require('../../../controllers/record-utils'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    recordUtils.createRecordByJSON,
-    recordUtils.createByForm
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/sms-gateway.js
+++ b/tests/unit/controllers/sms-gateway.js
@@ -1,15 +1,10 @@
 var controller = require('../../../controllers/sms-gateway'),
     messageUtils = require('../../../controllers/message-utils'),
     recordUtils = require('../../../controllers/record-utils'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    messageUtils.getMessages,
-    messageUtils.updateMessage,
-    recordUtils.createByForm
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/total-births.js
+++ b/tests/unit/controllers/total-births.js
@@ -1,8 +1,7 @@
 var controller = require('../../../controllers/total-births'),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.setUp = function(callback) {
   sinon.stub(config, 'get').returns({});
@@ -10,7 +9,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/upcoming-appointments.js
+++ b/tests/unit/controllers/upcoming-appointments.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/upcoming-appointments'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/upcoming-due-dates.js
+++ b/tests/unit/controllers/upcoming-due-dates.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/upcoming-due-dates'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -20,7 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function(callback) {
-  utils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 
@@ -51,23 +50,23 @@ exports['get returns zero if all registrations have delivered'] = function(test)
   var fti = sinon.stub(db, 'fti');
   fti.onFirstCall().callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 1,
           scheduled_tasks: [ {
             group: 1,
             due: moment().toISOString()
           } ]
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 2,
           scheduled_tasks: [ {
             group: 1,
             due: moment().toISOString()
           } ]
-        } 
+        }
       }
     ]
   });
@@ -92,23 +91,23 @@ exports['get returns all women with upcoming due dates'] = function(test) {
   // get registrations
   fti.onCall(0).callsArgWith(2, null, {
     rows: [
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 1,
           fields: { patient_name: 'sarah' },
           form: 'R',
           reported_date: today.clone().subtract(36, 'weeks').toISOString(),
           related_entities: { clinic: { id: 'x' } }
-        } 
+        }
       },
-      { 
-        doc: { 
+      {
+        doc: {
           patient_id: 2,
           fields: { patient_name: 'sally' },
           form: 'P',
           lmp_date: today.clone().subtract(40, 'weeks').toISOString(),
           related_entities: { clinic: { id: 'y' } }
-        } 
+        }
       }
     ]
   });
@@ -123,11 +122,11 @@ exports['get returns all women with upcoming due dates'] = function(test) {
   // get visits
   fti.onCall(2).callsArgWith(2, null, {
     rows: [
-      { doc: { 
+      { doc: {
         reported_date: today.clone().subtract(2, 'weeks').toISOString(),
         fields: { patient_id: 1 }
       } },
-      { doc: { 
+      { doc: {
         reported_date: today.clone().subtract(6, 'weeks').toISOString(),
         fields: { patient_id: 1 }
       } }

--- a/tests/unit/controllers/users.js
+++ b/tests/unit/controllers/users.js
@@ -2,8 +2,7 @@ var controller = require('../../../controllers/users'),
     people = require('../../../controllers/people'),
     places = require('../../../controllers/places'),
     db = require('../../../db'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var facilitya = { _id: 'a', name: 'aaron' },
     facilityb = { _id: 'b', name: 'brian' },
@@ -12,37 +11,7 @@ var facilitya = { _id: 'a', name: 'aaron' },
 var userData;
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.request,
-    db.getPath,
-    db.medic,
-    db.medic.get,
-    db.medic.insert,
-    db.medic.view,
-    db._users.get,
-    db._users.insert,
-    controller._mapUsers,
-    controller._createContact,
-    controller._createPlace,
-    controller._createUser,
-    controller._createUserSettings,
-    controller._getAllUsers,
-    controller._getAllUserSettings,
-    controller._getFacilities,
-    controller._setContactParent,
-    controller._validateUser,
-    controller._validateUserSettings,
-    controller._hasParent,
-    controller._updatePlace,
-    controller._updateUser,
-    controller._updateUserSettings,
-    controller._validateNewUsername,
-    controller.getList,
-    people.createPerson,
-    people.getOrCreatePerson,
-    places.getOrCreatePlace,
-    places.getPlace
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/utils.js
+++ b/tests/unit/controllers/utils.js
@@ -2,8 +2,7 @@ var utils = require('../../../controllers/utils'),
     db = require('../../../db'),
     config = require('../../../config'),
     moment = require('moment'),
-    testUtils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -13,7 +12,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  testUtils.restore(clock, db.fti, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/visits-complete.js
+++ b/tests/unit/controllers/visits-complete.js
@@ -1,8 +1,7 @@
 var controller = require('../../../controllers/visits-completed'),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.setUp = function(callback) {
   sinon.stub(config, 'get').returns({});
@@ -10,7 +9,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db.fti, db.medic.view, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/controllers/visits-during.js
+++ b/tests/unit/controllers/visits-during.js
@@ -1,8 +1,7 @@
 var controller = require('../../../controllers/visits-during'),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 exports.setUp = function(callback) {
   sinon.stub(config, 'get').returns({});
@@ -10,7 +9,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db.fti, db.medic.view, config.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/ddoc-extraction.js
+++ b/tests/unit/ddoc-extraction.js
@@ -1,10 +1,9 @@
 var ddocExtraction = require('../../ddoc-extraction'),
-    sinon = require('sinon'),
-    utils = require('./utils'),
+    sinon = require('sinon').sandbox.create(),
     db = require('../../db');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.get, db.medic.bulk);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/handlers/changes.js
+++ b/tests/unit/handlers/changes.js
@@ -1,8 +1,6 @@
-var sinon = require('sinon'),
-    testUtils = require('../utils'),
+var sinon = require('sinon').sandbox.create(),
     auth = require('../../../auth'),
     config = require('../../../config'),
-    serverUtils = require('../../../server-utils'),
     handler = require('../../../handlers/changes'),
     db = require('../../../db'),
     DDOC_ID = '_design/medic-client',
@@ -14,19 +12,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  testUtils.restore(
-    auth.getUserCtx,
-    auth.hasAllPermissions,
-    auth.getFacilityId,
-    auth.getContactId,
-    serverUtils.serverError,
-    serverUtils.error,
-    config.get,
-    console.error,
-    db.request,
-    db.medic.view,
-    db.medic.changes
-  );
+  sinon.restore();
   handler._reset();
   callback();
 };

--- a/tests/unit/migrations.js
+++ b/tests/unit/migrations.js
@@ -1,10 +1,9 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     migrations = require('../../migrations'),
-    utils = require('./utils'),
     db = require('../../db');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.view, db.medic.get, db.medic.insert, migrations.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/migrations/add-permissions-configuration.js
+++ b/tests/unit/migrations/add-permissions-configuration.js
@@ -1,10 +1,9 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
-    utils = require('../utils'),
     migration = require('../../../migrations/add-permissions-configuration');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.getSettings, db.request, db.getPath);
+  sinon.restore();
   db.settings = {};
   callback();
 };

--- a/tests/unit/migrations/associate-records-with-people.js
+++ b/tests/unit/migrations/associate-records-with-people.js
@@ -1,10 +1,9 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
-    utils = require('../utils'),
     migration = require('../../../migrations/associate-records-with-people');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.view, db.medic.get, db.medic.insert);
+  sinon.restore();
   callback();
 };
 
@@ -192,7 +191,7 @@ var outgoingMessageToPerson = {
                   phone: '+2884615402'
                 },
                 parent: {
-                  
+
                 }
               }
             }

--- a/tests/unit/migrations/extract-person-contacts.js
+++ b/tests/unit/migrations/extract-person-contacts.js
@@ -1,8 +1,7 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
     people = require('../../../controllers/people'),
     places = require('../../../controllers/places'),
-    utils = require('../utils'),
     migration = require('../../../migrations/extract-person-contacts');
 
 var createPerson, getDoc, getView, insertDoc, updatePlace;
@@ -17,7 +16,7 @@ exports.setUp = function(done) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db.medic.view, db.medic.get, db.medic.insert, people.createPerson, places.updatePlace);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/migrations/extract-translations.js
+++ b/tests/unit/migrations/extract-translations.js
@@ -1,10 +1,9 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
-    utils = require('../utils'),
     migration = require('../../../migrations/extract-translations');
 
 exports.tearDown = function (callback) {
-  utils.restore(db.getSettings, db.updateSettings, db.medic.view, db.medic.bulk);
+  sinon.restore();
   db.settings = {};
   callback();
 };

--- a/tests/unit/migrations/extract-user-settings.js
+++ b/tests/unit/migrations/extract-user-settings.js
@@ -1,6 +1,5 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
-    utils = require('../utils'),
     migration = require('../../../migrations/extract-user-settings');
 
 var ddoc = { id: '_design/_auth', key: '_design/_auth' };
@@ -42,7 +41,7 @@ var userB = {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(db._users.list, db._users.insert, db.medic.insert, db.medic.get);
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/migrations/namespace-form-fields.js
+++ b/tests/unit/migrations/namespace-form-fields.js
@@ -1,7 +1,6 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
     migration = require('../../../migrations/namespace-form-fields');
 
 var makeStubs = (...viewBatches) => {
@@ -34,12 +33,7 @@ var makeStubs = (...viewBatches) => {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.medic.view,
-    db.medic.bulk,
-    config.get,
-    config.load
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/migrations/separate-audit-db.js
+++ b/tests/unit/migrations/separate-audit-db.js
@@ -1,6 +1,5 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     db = require('../../../db'),
-    utils = require('../utils'),
     migration = require('../../../migrations/separate-audit-db.js');
 
 var ERR_404 = {statusCode: 404};
@@ -22,14 +21,7 @@ var LAST_VIEW_BATCH = {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    db.db.get,
-    db.db.create,
-    db.use,
-    db.medic.view,
-    db.db.replicate,
-    db.medic.fetchRevs,
-    db.medic.bulk);
+  sinon.restore();
 
   db.settings = {};
 

--- a/tests/unit/schedules/stats-submission.js
+++ b/tests/unit/schedules/stats-submission.js
@@ -1,9 +1,8 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     request = require('request'),
     schedule = require('../../../schedules/stats-submission'),
     db = require('../../../db'),
     config = require('../../../config'),
-    utils = require('../utils'),
     successfulResponse = JSON.stringify({ payload: { success: true }});
 
 var clock;
@@ -14,13 +13,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    clock,
-    db.medic.view,
-    db.medic.insert,
-    config.get,
-    request.post
-  );
+  sinon.restore();
   callback();
 };
 
@@ -234,7 +227,7 @@ exports['go submits populated submission string'] = function(test) {
       version: 2,
       visits_per_delivery: { '1+': 20, '2+': 19, '3+': 18, '4+': 17 },
       estimated_deliveries: 50,
-      valid_form_submissions: { _totalReports: 251, _totalMessages: 5, D: 60, F: 12, V: 101, R: 63, P: 15 }, 
+      valid_form_submissions: { _totalReports: 251, _totalMessages: 5, D: 60, F: 12, V: 101, R: 63, P: 15 },
       delivery_locations: { F: 23, S: 20 },
       active_facilities: { _total: 12, _totalReports: 11, _totalMessages: 4, D: 10, F: 5, V: 12, R: 1, P: 5 },
       type: 'usage_stats',
@@ -402,7 +395,7 @@ exports['go submits populated submission string for old style active_facilities'
     doc: {
       visits_per_delivery: { '1+': 20, '2+': 19, '3+': 18, '4+': 17 },
       estimated_deliveries: 50,
-      valid_form_submissions: { D: 60, F: 12, V: 101, R: 63, P: 15 }, 
+      valid_form_submissions: { D: 60, F: 12, V: 101, R: 63, P: 15 },
       delivery_locations: { F: 23, S: 20 },
       active_facilities: 20,
       type: 'usage_stats',

--- a/tests/unit/schedules/usage-stats.js
+++ b/tests/unit/schedules/usage-stats.js
@@ -1,8 +1,7 @@
 var schedule = require('../../../schedules/usage-stats'),
     db = require('../../../db'),
     utils = require('../../../controllers/utils'),
-    testUtils = require('../utils'),
-    sinon = require('sinon');
+    sinon = require('sinon').sandbox.create();
 
 var clock;
 
@@ -12,15 +11,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  testUtils.restore(
-    clock,
-    db.medic.view,
-    db.medic.insert,
-    utils.getBirthPatientIds,
-    utils.rejectDeliveries,
-    utils.getDeliveries,
-    utils.getVisits
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/server-utils.js
+++ b/tests/unit/server-utils.js
@@ -1,7 +1,6 @@
 var db = require('../../db'),
-    sinon = require('sinon'),
+    sinon = require('sinon').sandbox.create(),
     serverUtils = require('../../server-utils'),
-    utils = require('./utils'),
     req = {
       url: '',
       get: function() {}
@@ -20,16 +19,7 @@ exports.setUp = function(callback) {
 };
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    res.writeHead,
-    res.end,
-    res.redirect,
-    res.json,
-    res.status,
-    req.get,
-    serverUtils.serverError,
-    serverUtils.notLoggedIn
-  );
+  sinon.restore();
   db.settings = {};
   callback();
 };

--- a/tests/unit/translations.js
+++ b/tests/unit/translations.js
@@ -1,17 +1,10 @@
-var sinon = require('sinon'),
+var sinon = require('sinon').sandbox.create(),
     properties = require('properties'),
-    utils = require('./utils'),
     db = require('../../db'),
     translations = require('../../translations');
 
 exports.tearDown = function (callback) {
-  utils.restore(
-    properties.parse,
-    db.medic.get,
-    db.medic.attachment.get,
-    db.medic.view,
-    db.medic.bulk
-  );
+  sinon.restore();
   callback();
 };
 

--- a/tests/unit/utils.js
+++ b/tests/unit/utils.js
@@ -1,9 +1,0 @@
-module.exports = {
-  restore: function() {
-    for (var i = 0; i < arguments.length; i++) {
-      if (arguments[i].restore) {
-        arguments[i].restore();
-      }
-    }
-  }
-};


### PR DESCRIPTION
Replacing our pattern of passing a list of things that have maybe been
stubbed to a utility that restores them, and replacing it with sinon
sandboxes, the correct way to deal with this kind of thing.

This is better because it's fool-proof, you do not have to know what
things may or may not have been stubbed.

See: http://sinonjs.org/releases/v2.1.0/sandbox/sinon