### PR TITLE
node-uuid is now just uuid

### DIFF
--- a/migrations/add-uuid-to-scheduled-tasks.js
+++ b/migrations/add-uuid-to-scheduled-tasks.js
@@ -1,7 +1,7 @@
 var db = require('../db'),
     async = require('async'),
     moment = require('moment'),
-    uuid = require('node-uuid'),
+    uuidV4 = require('uuid/v4'),
     BATCH_SIZE = 100;
 
 var updateMessage = function(message) {
@@ -9,7 +9,7 @@ var updateMessage = function(message) {
     // already has the required uuid
     return false;
   }
-  message.uuid = uuid.v4();
+  message.uuid = uuidV4();
   return true;
 };
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "moment": "^2.10.6",
     "morgan": "^1.6.1",
     "nano": "^6.1.5",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.1",
     "object-path": "^0.11.1",
     "openrosa-formlist": "medic/openrosa-formlist#sax",
     "pass-stream": "^1.0.0",


### PR DESCRIPTION
Small review, just noticed when doing an `npm install` that node-uuid is the deprecated name.