### PR TITLE
Modifies migration so it doesn't conflict on update

### DIFF
--- a/migrations/namespace-form-fields.js
+++ b/migrations/namespace-form-fields.js
@@ -50,11 +50,12 @@ var namespace = function(docs, callback) {
 
 var runBatch = function(batchSize, skip, callback) {
   var options = {
+    key: [ 'data_record' ],
     include_docs: true,
     limit: batchSize,
     skip: skip
   };
-  db.medic.view('medic', 'data_records', options, function(err, result) {
+  db.medic.view('medic-client', 'doc_by_type', options, function(err, result) {
     if (err) {
       return callback(err);
     }

--- a/tests/integration/migrations/namespace-form-fields.js
+++ b/tests/integration/migrations/namespace-form-fields.js
@@ -1,0 +1,98 @@
+var utils = require('./utils');
+
+describe('namespace-form-fields migration', function() {
+  afterEach(function() {
+    return utils.tearDown();
+  });
+
+  it('should put form fields in fields property', function() {
+    // given
+
+    const needsMigration = {
+      _id: 'abc',
+      type: 'data_record',
+      form: 'R',
+      patient_name: 'Henok'
+    };
+
+    const alreadyMigrated = {
+      _id: 'def',
+      type: 'data_record',
+      form: 'R',
+      fields: {
+        patient_name: 'Dave'
+      }
+    };
+
+    const unknownForm = {
+      _id: 'hij',
+      type: 'data_record',
+      form: 'P',
+      patient_name: 'Marc'
+    };
+
+    return utils.initSettings({
+      forms: { // this is the default config
+        R: {
+          meta: {
+            code: 'R',
+            icon: 'registration',
+            label: {
+              en: 'Pregnancy Registration'
+            }
+          },
+          fields: {
+            patient_name: {
+              labels: {
+                tiny: {
+                  en: 'N'
+                },
+                description: {
+                  en: 'Patient Name'
+                },
+                short: {
+                  en: 'Name'
+                }
+              },
+              position: 0,
+              type: 'string',
+              length: [
+                1,
+                30
+              ],
+              required: true
+            }
+          },
+          public_form: true,
+          use_sentinel: true
+        }
+      }
+    })
+    .then(function() {
+      return utils.initDb([ needsMigration, alreadyMigrated, unknownForm ]);
+    })
+    .then(function() {
+
+      // when
+      return utils.runMigration('namespace-form-fields');
+
+    })
+    .then(function() {
+
+      // expect
+      return utils.assertDb([
+        {
+          _id: 'abc',
+          type: 'data_record',
+          form: 'R',
+          fields: {
+            patient_name: 'Henok'
+          }
+        },
+        alreadyMigrated,
+        unknownForm
+      ]);
+
+    });
+  });
+});


### PR DESCRIPTION
The data_records migration emits each doc multiple times so it's
possible to try and update the same document twice in one batch.
Instead we should use a different view that only emits once.

medic/medic-webapp#3534