### PR TITLE
Adds support for storing read status in meta db

### DIFF
--- a/controllers/create-user-db.js
+++ b/controllers/create-user-db.js
@@ -12,7 +12,7 @@ const createDatabase = (username, callback) => {
     const params = {
       db: dbName,
       path: '/_security',
-      method: 'put',
+      method: 'PUT',
       body: {
         admins: { names: [ username ], roles: [] },
         members: { names: [], roles:[] }

--- a/controllers/create-user-db.js
+++ b/controllers/create-user-db.js
@@ -1,26 +1,5 @@
-const db = require('../db'),
-      auth = require('../auth');
-
-const getDbName = username => `medic-user-${username}-meta`;
-
-const createDatabase = (username, callback) => {
-  const dbName = getDbName(username);
-  db.db.create(dbName, err => {
-    if (err) {
-      return callback(err);
-    }
-    const params = {
-      db: dbName,
-      path: '/_security',
-      method: 'PUT',
-      body: {
-        admins: { names: [ username ], roles: [] },
-        members: { names: [], roles:[] }
-      }
-    };
-    db.request(params, callback);
-  });
-};
+const auth = require('../auth'),
+      userDb = require('../lib/user-db');
 
 const checkPermissions = (req, callback) => {
   auth.getUserCtx(req, (err, userCtx) => {
@@ -28,7 +7,7 @@ const checkPermissions = (req, callback) => {
       return callback(err);
     }
     const username = userCtx.name;
-    if (req.url !== '/' + getDbName(username) + '/') {
+    if (req.url !== '/' + userDb.getDbName(username) + '/') {
       // trying to create a db with a disallowed name
       return callback({ code: 403, message: 'Insufficient privileges' });
     }
@@ -41,6 +20,6 @@ module.exports = (req, callback) => {
     if (err) {
       return callback(err);
     }
-    createDatabase(username, callback);
+    userDb.create(username, callback);
   });
 };

--- a/controllers/create-user-db.js
+++ b/controllers/create-user-db.js
@@ -1,0 +1,46 @@
+const db = require('../db'),
+      auth = require('../auth');
+
+const getDbName = username => `medic-user-${username}-meta`;
+
+const createDatabase = (username, callback) => {
+  const dbName = getDbName(username);
+  db.db.create(dbName, err => {
+    if (err) {
+      return callback(err);
+    }
+    const params = {
+      db: dbName,
+      path: '/_security',
+      method: 'put',
+      body: {
+        admins: { names: [ username ], roles: [] },
+        members: { names: [], roles:[] }
+      }
+    };
+    db.request(params, callback);
+  });
+};
+
+const checkPermissions = (req, callback) => {
+  auth.getUserCtx(req, (err, userCtx) => {
+    if (err) {
+      return callback(err);
+    }
+    const username = userCtx.name;
+    if (req.url !== '/' + getDbName(username) + '/') {
+      // trying to create a db with a disallowed name
+      return callback({ code: 403, message: 'Insufficient privileges' });
+    }
+    return callback(null, username);
+  });
+};
+
+module.exports = (req, callback) => {
+  checkPermissions(req, (err, username) => {
+    if (err) {
+      return callback(err);
+    }
+    createDatabase(username, callback);
+  });
+};

--- a/db.js
+++ b/db.js
@@ -131,6 +131,17 @@ if (couchUrl) {
     });
   };
 
+  /**
+   * Run an operation over all documents returned from the query in batches.
+   *
+   * query function     Called with a skip number and a callback to
+   *                    invoke with the next batch.
+   * iteratee function  Called with an array of rows and a callback to
+   *                    invoke when rows have been processed and persisted.
+   * batchSize int      The size each batch should be.
+   * callback function  Called when no more rows are returned from the
+   *                    query function.
+   */
   module.exports.batch = (query, iteratee, batchSize, callback) => {
     let skip = 0;
     async.doWhilst(

--- a/db.js
+++ b/db.js
@@ -124,7 +124,7 @@ if (couchUrl) {
         return callback(err);
       }
       console.log(`        Processing ${skip} to ${skip + batchSize} docs of ${response.total_rows} total`);
-      iteratee(response.rows, err => {
+      iteratee(response, err => {
         const keepGoing = response.total_rows > (skip + batchSize);
         callback(err, keepGoing);
       });
@@ -136,7 +136,7 @@ if (couchUrl) {
    *
    * query function     Called with a skip number and a callback to
    *                    invoke with the next batch.
-   * iteratee function  Called with an array of rows and a callback to
+   * iteratee function  Called with the query response and a callback to
    *                    invoke when rows have been processed and persisted.
    * batchSize int      The size each batch should be.
    * callback function  Called when no more rows are returned from the

--- a/lib/user-db.js
+++ b/lib/user-db.js
@@ -1,4 +1,5 @@
-const db = require('../db');
+const db = require('../db'),
+      async = require('async');
 
 const readMapFunction = function(doc) {
   var parts = doc._id.split(':');
@@ -41,16 +42,10 @@ module.exports = {
   getDbName: username => `medic-user-${username}-meta`,
   create: (username, callback) => {
     const dbName = module.exports.getDbName(username);
-    createDb(dbName, err => {
-      if (err) {
-        return callback(err);
-      }
-      setSecurity(dbName, username, err => {
-        if (err) {
-          return callback(err);
-        }
-        putDdoc(dbName, callback);
-      });
-    });
+    async.series([
+      async.apply(createDb, dbName),
+      async.apply(setSecurity, dbName, username),
+      async.apply(putDdoc, dbName)
+    ], callback);
   }
 };

--- a/lib/user-db.js
+++ b/lib/user-db.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const readMapFunction = function(doc) {
+  var parts = doc._id.split(':');
+  if (parts[0] === 'read') {
+    emit(parts[1]);
+  }
+};
+
+const ddoc = {
+  _id: '_design/medic-user',
+  views: {
+    read: {
+      map: readMapFunction.toString(),
+      reduce: '_count'
+    }
+  }
+};
+
+const createDb = (dbName, callback) => {
+  db.db.create(dbName, callback);
+};
+
+const setSecurity = (dbName, username, callback) => {
+  db.request({
+    db: dbName,
+    path: '/_security',
+    method: 'PUT',
+    body: {
+      admins: { names: [ username ], roles: [] },
+      members: { names: [], roles:[] }
+    }
+  }, callback);
+};
+
+const putDdoc = (dbName, callback) => {
+  db.use(dbName).insert(ddoc, callback);
+};
+
+module.exports = {
+  getDbName: username => `medic-user-${username}-meta`,
+  create: (username, callback) => {
+    const dbName = module.exports.getDbName(username);
+    createDb(dbName, err => {
+      if (err) {
+        return callback(err);
+      }
+      setSecurity(dbName, username, err => {
+        if (err) {
+          return callback(err);
+        }
+        putDdoc(dbName, callback);
+      });
+    });
+  }
+};

--- a/migrations/extract-read-status.js
+++ b/migrations/extract-read-status.js
@@ -29,9 +29,9 @@ const saveReadStatusDocs = (username, docs, callback) => {
   });
 };
 
-const extract = (rows, callback) => {
+const extract = (response, callback) => {
   const toSave = {};
-  rows.forEach(row => {
+  response.rows.forEach(row => {
     const doc = row.doc;
     if (doc.read) {
       doc.read.forEach(user => {

--- a/migrations/extract-read-status.js
+++ b/migrations/extract-read-status.js
@@ -18,7 +18,7 @@ const createDb = (username, dbName, callback) => {
     const params = {
       db: dbName,
       path: '/_security',
-      method: 'put',
+      method: 'PUT',
       body: {
         admins: { names: [ username ], roles: [] },
         members: { names: [], roles:[] }
@@ -33,7 +33,7 @@ const ensureDbExists = (username, dbName, callback) => {
     if (err && err.statusCode === 404) {
       return createDb(username, dbName, callback);
     }
-    callback();
+    callback(err);
   });
 };
 

--- a/migrations/extract-read-status.js
+++ b/migrations/extract-read-status.js
@@ -1,8 +1,7 @@
 const db = require('../db'),
       async = require('async'),
+      userDb = require('../lib/user-db'),
       BATCH_SIZE = 100;
-
-const getDbName = username => `medic-user-${username}-meta`;
 
 const createReadStatusDoc = record => {
   const type = record.form ? 'report' : 'message';
@@ -10,35 +9,17 @@ const createReadStatusDoc = record => {
   return { _id: id };
 };
 
-const createDb = (username, dbName, callback) => {
-  db.db.create(dbName, err => {
-    if (err) {
-      return callback(err);
-    }
-    const params = {
-      db: dbName,
-      path: '/_security',
-      method: 'PUT',
-      body: {
-        admins: { names: [ username ], roles: [] },
-        members: { names: [], roles:[] }
-      }
-    };
-    db.request(params, callback);
-  });
-};
-
 const ensureDbExists = (username, dbName, callback) => {
   db.db.get(dbName, err => {
     if (err && err.statusCode === 404) {
-      return createDb(username, dbName, callback);
+      return userDb.create(username, callback);
     }
     callback(err);
   });
 };
 
 const saveReadStatusDocs = (username, docs, callback) => {
-  const userDbName = getDbName(username);
+  const userDbName = userDb.getDbName(username);
   ensureDbExists(username, userDbName, err => {
     if (err) {
       return callback(err);

--- a/migrations/extract-read-status.js
+++ b/migrations/extract-read-status.js
@@ -1,0 +1,87 @@
+const db = require('../db'),
+      async = require('async'),
+      BATCH_SIZE = 100;
+
+const getDbName = username => `medic-user-${username}-meta`;
+
+const createReadStatusDoc = record => {
+  const type = record.form ? 'report' : 'message';
+  const id = `read:${type}:${record._id}`;
+  return { _id: id };
+};
+
+const createDb = (username, dbName, callback) => {
+  db.db.create(dbName, err => {
+    if (err) {
+      return callback(err);
+    }
+    const params = {
+      db: dbName,
+      path: '/_security',
+      method: 'put',
+      body: {
+        admins: { names: [ username ], roles: [] },
+        members: { names: [], roles:[] }
+      }
+    };
+    db.request(params, callback);
+  });
+};
+
+const ensureDbExists = (username, dbName, callback) => {
+  db.db.get(dbName, err => {
+    if (err && err.statusCode === 404) {
+      return createDb(username, dbName, callback);
+    }
+    callback();
+  });
+};
+
+const saveReadStatusDocs = (username, docs, callback) => {
+  const userDbName = getDbName(username);
+  ensureDbExists(username, userDbName, err => {
+    if (err) {
+      return callback(err);
+    }
+    const userDb = db.use(userDbName);
+    userDb.bulk({ docs: docs }, callback);
+  });
+};
+
+const extract = (rows, callback) => {
+  const toSave = {};
+  rows.forEach(row => {
+    const doc = row.doc;
+    if (doc.read) {
+      doc.read.forEach(user => {
+        if (!toSave[user]) {
+          toSave[user] = [];
+        }
+        toSave[user].push(createReadStatusDoc(doc));
+      });
+    }
+  });
+  async.each(
+    Object.keys(toSave),
+    (username, callback) => saveReadStatusDocs(username, toSave[username], callback),
+    callback
+  );
+};
+
+const query = (skip, callback) => {
+  const options = {
+    key: [ 'data_record' ],
+    include_docs: true,
+    limit: BATCH_SIZE,
+    skip: skip
+  };
+  db.medic.view('medic-client', 'doc_by_type', options, callback);
+};
+
+module.exports = {
+  name: 'extract-read-status',
+  created: new Date(2017, 6, 7),
+  run: callback => {
+    db.batch(query, extract, BATCH_SIZE, callback);
+  }
+};

--- a/server.js
+++ b/server.js
@@ -758,7 +758,8 @@ async.series([
   async.asyncify(scheduler.init)
 ], err => {
   if (err) {
-    console.error('Fatal error initialising medic-api', err);
+    console.error('Fatal error initialising medic-api');
+    console.error(err);
     process.exit(1);
   }
 

--- a/server.js
+++ b/server.js
@@ -568,6 +568,16 @@ var changesHander = _.partial(require('./handlers/changes').request, proxy);
 app.get(pathPrefix + '_changes', changesHander);
 app.post(pathPrefix + '_changes', jsonParser, changesHander);
 
+// Attempting to create the user's personal meta db
+app.put('/medic-user-\*-meta/', (req, res) => {
+  require('./controllers/create-user-db')(req, err => {
+    if (err) {
+      return serverUtils.error(err, req, res);
+    }
+    res.json({ ok: true });
+  });
+});
+
 var writeHeaders = function(req, res, headers, redirectHumans) {
   res.oldWriteHead = res.writeHead;
   res.writeHead = function(_statusCode, _headers) {

--- a/tests/unit/controllers/create-user-db.js
+++ b/tests/unit/controllers/create-user-db.js
@@ -40,7 +40,7 @@ exports['creates the database and sets permissions'] = test => {
     const requestParams = request.args[0][0];
     test.equals(requestParams.db, 'medic-user-gareth-meta');
     test.equals(requestParams.path, '/_security');
-    test.equals(requestParams.method, 'put');
+    test.equals(requestParams.method, 'PUT');
     test.equals(requestParams.body.admins.names[0], 'gareth');
     test.done();
   });

--- a/tests/unit/controllers/create-user-db.js
+++ b/tests/unit/controllers/create-user-db.js
@@ -1,0 +1,47 @@
+var controller = require('../../../controllers/create-user-db'),
+    db = require('../../../db'),
+    auth = require('../../../auth'),
+    sinon = require('sinon').sandbox.create();
+
+exports.tearDown = callback => {
+  sinon.restore();
+  callback();
+};
+
+exports['returns error when not logged in'] = test => {
+  const req = {};
+  const getUserCtx = sinon.stub(auth, 'getUserCtx').callsArgWith(1, 'bang');
+  controller(req, err => {
+    test.equals(err, 'bang');
+    test.equals(getUserCtx.callCount, 1);
+    test.done();
+  });
+};
+
+exports['returns error when putting an invalid db name'] = test => {
+  const req = { url: '/medic-user-supersecret-meta/' };
+  sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, { name: 'gareth' });
+  controller(req, err => {
+    test.equals(err.code, 403);
+    test.done();
+  });
+};
+
+exports['creates the database and sets permissions'] = test => {
+  const req = { url: '/medic-user-gareth-meta/' };
+  sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, { name: 'gareth' });
+  const create = sinon.stub(db.db, 'create').callsArgWith(1);
+  const request = sinon.stub(db, 'request').callsArgWith(1);
+  controller(req, err => {
+    test.equals(err, null);
+    test.equals(create.callCount, 1);
+    test.equals(create.args[0][0], 'medic-user-gareth-meta');
+    test.equals(request.callCount, 1);
+    const requestParams = request.args[0][0];
+    test.equals(requestParams.db, 'medic-user-gareth-meta');
+    test.equals(requestParams.path, '/_security');
+    test.equals(requestParams.method, 'put');
+    test.equals(requestParams.body.admins.names[0], 'gareth');
+    test.done();
+  });
+};

--- a/tests/unit/controllers/create-user-db.js
+++ b/tests/unit/controllers/create-user-db.js
@@ -1,6 +1,6 @@
 var controller = require('../../../controllers/create-user-db'),
-    db = require('../../../db'),
     auth = require('../../../auth'),
+    userDb = require('../../../lib/user-db'),
     sinon = require('sinon').sandbox.create();
 
 exports.tearDown = callback => {
@@ -30,18 +30,11 @@ exports['returns error when putting an invalid db name'] = test => {
 exports['creates the database and sets permissions'] = test => {
   const req = { url: '/medic-user-gareth-meta/' };
   sinon.stub(auth, 'getUserCtx').callsArgWith(1, null, { name: 'gareth' });
-  const create = sinon.stub(db.db, 'create').callsArgWith(1);
-  const request = sinon.stub(db, 'request').callsArgWith(1);
+  const create = sinon.stub(userDb, 'create').callsArgWith(1);
   controller(req, err => {
     test.equals(err, null);
     test.equals(create.callCount, 1);
-    test.equals(create.args[0][0], 'medic-user-gareth-meta');
-    test.equals(request.callCount, 1);
-    const requestParams = request.args[0][0];
-    test.equals(requestParams.db, 'medic-user-gareth-meta');
-    test.equals(requestParams.path, '/_security');
-    test.equals(requestParams.method, 'PUT');
-    test.equals(requestParams.body.admins.names[0], 'gareth');
+    test.equals(create.args[0][0], 'gareth');
     test.done();
   });
 };

--- a/tests/unit/lib/user-db.js
+++ b/tests/unit/lib/user-db.js
@@ -1,0 +1,33 @@
+var lib = require('../../../lib/user-db'),
+    db = require('../../../db'),
+    sinon = require('sinon').sandbox.create();
+
+exports.tearDown = callback => {
+  sinon.restore();
+  callback();
+};
+
+exports['creates the db'] = test => {
+  const create = sinon.stub(db.db, 'create').callsArgWith(1);
+  const request = sinon.stub(db, 'request').callsArgWith(1);
+  const insert = sinon.stub().callsArgWith(1);
+  const use = sinon.stub(db, 'use').returns({ insert: insert });
+  lib.create('gareth', err => {
+    test.equals(err, null);
+    test.equals(create.args[0][0], 'medic-user-gareth-meta');
+    test.equals(request.callCount, 1);
+    const requestParams = request.args[0][0];
+    test.equals(requestParams.db, 'medic-user-gareth-meta');
+    test.equals(requestParams.path, '/_security');
+    test.equals(requestParams.method, 'PUT');
+    test.equals(requestParams.body.admins.names[0], 'gareth');
+    test.equals(use.callCount, 1);
+    test.equals(use.args[0][0], 'medic-user-gareth-meta');
+    test.equals(insert.callCount, 1);
+    const ddoc = insert.args[0][0];
+    test.equals(ddoc._id, '_design/medic-user');
+    test.equals(ddoc.views.read.map, 'function (doc) {\n  var parts = doc._id.split(\':\');\n  if (parts[0] === \'read\') {\n    emit(parts[1]);\n  }\n}');
+    test.equals(ddoc.views.read.reduce, '_count');
+    test.done();
+  });
+};

--- a/tests/unit/migrations.js
+++ b/tests/unit/migrations.js
@@ -185,7 +185,7 @@ exports['executes multiple migrations and stops when one errors'] = function(tes
   sinon.stub(migrations, 'get').callsArgWith(0, null, migration);
   var saveDoc = sinon.stub(db.medic, 'insert').callsArg(1);
   migrations.run(function(err) {
-    test.equals(err, 'Migration "b" failed with: "boom!"');
+    test.equals(err, 'boom!');
     test.equals(getLog.callCount, 2);
     test.equals(saveDoc.callCount, 1);
     test.deepEqual(saveDoc.firstCall.args[0], {


### PR DESCRIPTION
Adds a migration to extract the read status from the docs and
into the meta db.

Adds an endpoint to handle the lazy creation of the user meta
db.

Also improves the migration output to be formatted rather than
stringifying the Error.

medic/medic-webapp#2418