### PR TITLE
Improves pagination strategy of bulk get

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,8 +1,7 @@
 var path = require('path'),
     url = require('url'),
     nano = require('nano'),
-    request = require('request'),
-    async = require('async');
+    request = require('request');
 
 var couchUrl = process.env.COUCH_URL;
 var luceneUrl = process.env.LUCENE_URL;
@@ -117,42 +116,6 @@ if (couchUrl) {
   };
 
   module.exports.sanitizeResponse = sanitizeResponse;
-
-  const runBatch = (query, iteratee, batchSize, skip, callback) => {
-    query(skip, (err, response) => {
-      if (err) {
-        return callback(err);
-      }
-      console.log(`        Processing doc ${skip}`);
-      iteratee(response, err => {
-        // keep going if at least one row was found last time
-        callback(err, !!response.rows.length);
-      });
-    });
-  };
-
-  /**
-   * Run an operation over all documents returned from the query in batches.
-   *
-   * query function     Called with a skip number and a callback to
-   *                    invoke with the next batch.
-   * iteratee function  Called with the query response and a callback to
-   *                    invoke when rows have been processed and persisted.
-   * batchSize int      The size each batch should be.
-   * callback function  Called when no more rows are returned from the
-   *                    query function.
-   */
-  module.exports.batch = (query, iteratee, batchSize, callback) => {
-    let skip = 0;
-    async.doWhilst(
-      callback => runBatch(query, iteratee, batchSize, skip, callback),
-      keepGoing => {
-        skip += batchSize;
-        return keepGoing;
-      },
-      callback
-    );
-  };
 } else if (process.env.UNIT_TEST_ENV) {
   // Running tests only
   module.exports = {

--- a/lib/db-batch.js
+++ b/lib/db-batch.js
@@ -1,0 +1,55 @@
+const async = require('async'),
+      _ = require('underscore'),
+      db = require('../db'),
+      DEFAULT_BATCH_LIMIT = 100; // 100 is a good compromise of performance and stability
+
+const runBatch = (ddocName, viewName, viewParams, iteratee, callback) => {
+  db.medic.view(ddocName, viewName, viewParams, (err, response) => {
+    if (err) {
+      return callback(err);
+    }
+    console.log(`        Processing doc ${response.offset}`);
+    let nextPage;
+    if (response.rows.length === viewParams.limit) {
+      const lastRow = response.rows.pop();
+      nextPage = {
+        startkey: lastRow.key,
+        startkey_docid: lastRow.id
+      };
+    }
+    const docs = response.rows.map(row => row.doc);
+    iteratee(docs, err => {
+      callback(err, nextPage);
+    });
+  });
+};
+
+/**
+ * Run an operation over all documents returned from the query in batches.
+ * TODO fix this - now completely wrong
+ *
+ * ddocName (string)    Name of the ddoc the view is defined in.
+ * viewName (string)    Name of the view.
+ * viewParams (object)  Parameters to pass to the view query.
+ *  - `limit` defaults to 100 and can be overriden.
+ *  - `include_docs` defaults to `true` and cannot be overriden.
+ *  - `startkey` and `startkey_docid` cannot be overriden.
+ * iteratee (function)  Called to process an array of docs then invoke the given callback.
+ * callback (function)  Called on error or when all docs have been processed.
+ */
+module.exports.view = (ddocName, viewName, viewParams, iteratee, callback) => {
+  // add 1 so we know where to start from next iteration
+  viewParams.limit = (viewParams.limit || DEFAULT_BATCH_LIMIT) + 1;
+  viewParams.include_docs = true;
+  async.doWhilst(
+    callback => runBatch(ddocName, viewName, viewParams, iteratee, callback),
+    nextPage => {
+      if (!nextPage) {
+        return false;
+      }
+      viewParams = _.defaults(nextPage, viewParams);
+      return true;
+    },
+    callback
+  );
+};

--- a/lib/db-batch.js
+++ b/lib/db-batch.js
@@ -26,7 +26,6 @@ const runBatch = (ddocName, viewName, viewParams, iteratee, callback) => {
 
 /**
  * Run an operation over all documents returned from the query in batches.
- * TODO fix this - now completely wrong
  *
  * ddocName (string)    Name of the ddoc the view is defined in.
  * viewName (string)    Name of the view.

--- a/tests/unit/lib/db-batch.js
+++ b/tests/unit/lib/db-batch.js
@@ -1,0 +1,86 @@
+const lib = require('../../../lib/db-batch'),
+      db = require('../../../db'),
+      sinon = require('sinon').sandbox.create(),
+      ddocName = 'myddoc',
+      viewName = 'myview',
+      viewKey = 'mykey';
+
+let iteratee;
+
+exports.setUp = callback => {
+  iteratee = sinon.stub();
+  callback();
+};
+
+exports.tearDown = callback => {
+  sinon.restore();
+  callback();
+};
+
+exports['errors if the view errors'] = test => {
+  sinon.stub(db.medic, 'view').callsArgWith(3, 'boom');
+  lib.view(ddocName, viewName, { key: viewKey }, iteratee, err => {
+    test.equals(err, 'boom');
+    test.done();
+  });
+};
+
+exports['errors if the iteratee errors'] = test => {
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: { _id: 'a' } } ] });
+  iteratee.callsArgWith(1, 'boo');
+  lib.view(ddocName, viewName, { key: viewKey }, iteratee, err => {
+    test.equals(err, 'boo');
+    test.done();
+  });
+};
+
+exports['works with a single page'] = test => {
+  const doc1 = { _id: 'a' };
+  const doc2 = { _id: 'b' };
+  const view = sinon.stub(db.medic, 'view').callsArgWith(3, null, { rows: [ { doc: doc1 }, { doc: doc2 } ] });
+  iteratee.callsArgWith(1);
+  lib.view(ddocName, viewName, { key: viewKey }, iteratee, err => {
+    test.equals(err, null);
+    test.equals(view.callCount, 1);
+    test.equals(view.args[0][0], ddocName);
+    test.equals(view.args[0][1], viewName);
+    test.equals(view.args[0][2].key, viewKey);
+    test.equals(view.args[0][2].include_docs, true);
+    test.equals(view.args[0][2].limit, 101); // default limit is 100
+    test.equals(iteratee.callCount, 1);
+    test.deepEqual(iteratee.args[0][0], [ doc1, doc2 ]);
+    test.done();
+  });
+};
+
+exports['works with multiple pages'] = test => {
+  const row1 = { key: viewKey, id: 'a', doc: { _id: 'a' } };
+  const row2 = { key: viewKey, id: 'b', doc: { _id: 'b' } };
+  const row3 = { key: viewKey, id: 'c', doc: { _id: 'c' } };
+  const row4 = { key: viewKey, id: 'd', doc: { _id: 'd' } };
+  const row5 = { key: viewKey, id: 'e', doc: { _id: 'e' } };
+  const row6 = { key: viewKey, id: 'f', doc: { _id: 'f' } };
+  const view = sinon.stub(db.medic, 'view');
+  view.onCall(0).callsArgWith(3, null, { rows: [ row1, row2, row3 ] });
+  view.onCall(1).callsArgWith(3, null, { rows: [ row3, row4, row5 ] });
+  view.onCall(2).callsArgWith(3, null, { rows: [ row5, row6 ] });
+  iteratee.callsArgWith(1);
+  lib.view(ddocName, viewName, { key: viewKey, limit: 2 }, iteratee, err => {
+    test.equals(err, null);
+    test.equals(view.callCount, 3);
+    test.equals(view.args[0][2].limit, 3); // given limit plus 1
+    test.equals(view.args[0][2].startkey, undefined);
+    test.equals(view.args[0][2].startkey_docid, undefined);
+    test.equals(view.args[1][2].limit, 3);
+    test.equals(view.args[1][2].startkey, viewKey);
+    test.equals(view.args[1][2].startkey_docid, 'c');
+    test.equals(view.args[2][2].limit, 3);
+    test.equals(view.args[2][2].startkey, viewKey);
+    test.equals(view.args[2][2].startkey_docid, 'e');
+    test.equals(iteratee.callCount, 3);
+    test.deepEqual(iteratee.args[0][0], [ row1.doc, row2.doc ]);
+    test.deepEqual(iteratee.args[1][0], [ row3.doc, row4.doc ]);
+    test.deepEqual(iteratee.args[2][0], [ row5.doc, row6.doc ]);
+    test.done();
+  });
+};


### PR DESCRIPTION
Pulls out the db.batch function into lib/db-batch

Uses the startkey strategy instead of skip for improved
performance and removing the chance of missing records due to
view reordering.

medic/medic-webapp#3553