### PR TITLE
Return the correct error message medic/medic-webapp#3587

### DIFF
--- a/controllers/messages.js
+++ b/controllers/messages.js
@@ -59,13 +59,13 @@ const applyTaskStateChangesToDocs = (taskStateChanges, docs) => {
 
   taskStateChanges.forEach(taskStateChange => {
     if (!taskStateChange.messageId) {
-      throw Error('Message id required');
+      throw {code: 400, message: 'Message id required'};
     }
 
     const {task, docId} = getTaskAndDocForMessage(taskStateChange.messageId, docs);
 
     if (!task) {
-      throw Error(`Message not found: ${taskStateChange.messageId}`);
+      throw {code: 404, message: `Message not found: ${taskStateChange.messageId}`};
     }
 
     fillTaskStateChangeByDocId(taskStateChange, docId);

--- a/controllers/messages.js
+++ b/controllers/messages.js
@@ -39,6 +39,8 @@ const getTaskAndDocForMessage = function (messageId, docs) {
       return [task, doc._id];
     }
   }
+
+  return [null,null];
 };
 
 /*

--- a/controllers/messages.js
+++ b/controllers/messages.js
@@ -36,11 +36,11 @@ const getTaskAndDocForMessage = function (messageId, docs) {
   for (const doc of docs) {
     const task = getTaskForMessage(messageId, doc);
     if (task) {
-      return [task, doc._id];
+      return {task: task, docId: doc._id};
     }
   }
 
-  return [null,null];
+  return {};
 };
 
 /*
@@ -62,7 +62,7 @@ const applyTaskStateChangesToDocs = (taskStateChanges, docs) => {
       throw Error('Message id required');
     }
 
-    const [task, docId] = getTaskAndDocForMessage(taskStateChange.messageId, docs);
+    const {task, docId} = getTaskAndDocForMessage(taskStateChange.messageId, docs);
 
     if (!task) {
       throw Error(`Message not found: ${taskStateChange.messageId}`);

--- a/tests/unit/controllers/messages.js
+++ b/tests/unit/controllers/messages.js
@@ -150,6 +150,42 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
   });
 };
 
+exports['updateMessageTaskStates throws an error if it cant find the message'] = test => {
+  sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: [
+    {id: 'testMessageId1'}]});
+
+  sinon.stub(db.medic, 'fetch').callsArgWith(1, null, {rows: [
+    {doc: {
+      _id: 'testDoc',
+      tasks: [{
+        messages: [{
+          uuid: 'testMessageId1'
+        }]
+      }]
+    }}
+  ]});
+
+  sinon.stub(db.medic, 'bulk').callsArgWith(1, null, []);
+
+  controller.updateMessageTaskStates([
+    {
+      messageId: 'testMessageId1',
+      state: 'testState1',
+    },
+    {
+      messageId: 'testMessageId2',
+      state: 'testState2',
+      details: 'Just because.'
+    }
+  ], (err) => {
+    test.ok(err);
+
+    test.equal(err.message, `Message not found: testMessageId2`);
+
+    test.done();
+  });
+};
+
 exports['updateMessageTaskStates re-applies changes if it errored'] = test => {
   const view = sinon.stub(db.medic, 'view')
   .onFirstCall().callsArgWith(3, null, {rows: [

--- a/tests/unit/controllers/messages.js
+++ b/tests/unit/controllers/messages.js
@@ -180,6 +180,7 @@ exports['updateMessageTaskStates throws an error if it cant find the message'] =
   ], (err) => {
     test.ok(err);
 
+    test.equal(err.code, 404);
     test.equal(err.message, `Message not found: testMessageId2`);
 
     test.done();


### PR DESCRIPTION
If you try to destructure undefined it gives you a really confusing
error message:
TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined

Instead, if we can't find the task return null, and have our correct
existing error message handle it