### PR TITLE
Improving security error message medic/medic-webapp#3606

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: node_js
 sudo: false
-node_js:
-  # - "node"
+node_js: 
+  - "node"
   - "6.5"
 
 before_script:
   - npm install grunt-cli -g
 
-script:
+script: 
   - grunt ci
 
 notifications:
-  webhooks:
+  webhooks: 
     urls:
       - https://medic.slack.com/services/hooks/travis?token=xcYT8yusfEdSwLskhBxK4Vwj
     on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: node_js
 sudo: false
-node_js: 
-  - "node"
+node_js:
+  # - "node"
   - "6.5"
 
 before_script:
   - npm install grunt-cli -g
 
-script: 
+script:
   - grunt ci
 
 notifications:
-  webhooks: 
+  webhooks:
     urls:
       - https://medic.slack.com/services/hooks/travis?token=xcYT8yusfEdSwLskhBxK4Vwj
     on_success: change

--- a/server.js
+++ b/server.js
@@ -737,7 +737,9 @@ const couchDbNoAdminPartyModeCheck = callback => {
     if (statusCode === 401) {
       callback();
     } else {
-      callback(new Error('CouchDB Admin Party Mode detected, please disable: https://github.com/medic/medic-webapp#disable-couchdb-admin-party-mode'));
+      console.error('Expected a 401 when accessing db without authentication.');
+      console.error(`Instead we got a ${statusCode}`).
+      callback(new Error('CouchDB security seems to be misconfigured, see: https://github.com/medic/medic-webapp#enabling-a-secure-couchdb'));
     }
   });
 };


### PR DESCRIPTION
# Description

Hopefully a clearer explanation
Outputting the incorrect statusCode for debugging in case checking for
401 is not the perfect test
Correctly linking to the (new) README section on security

medic/medic-webapp#3606

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.