### PR TITLE
Allow for empty sms

### DIFF
--- a/controllers/record-utils.js
+++ b/controllers/record-utils.js
@@ -23,7 +23,7 @@ var request = function(opts, callback) {
 
 var createByForm = function(data, callback) {
   if (empty(data.from)) {
-    return callback(new Error('Missing required field: from'));
+    return callback(new Error('Missing required value: from'));
   }
 
   // We're OK with message being empty, but the field should exist

--- a/controllers/record-utils.js
+++ b/controllers/record-utils.js
@@ -1,7 +1,7 @@
 var _ = require('underscore'),
     db = require('../db');
 
-var exists = function(val) {
+var empty = function(val) {
   return val !== '' && typeof val !== 'undefined';
 };
 
@@ -20,11 +20,11 @@ var request = function(opts, callback) {
 };
 
 var createByForm = function(data, callback) {
-  var required = ['message', 'from'],
-      optional = ['reported_date', 'locale', 'gateway_ref'];
+  var required = ['from'],
+      optional = ['message', 'reported_date', 'locale', 'gateway_ref'];
   for (var k in required) {
     if (required.hasOwnProperty(k)) {
-      if (!exists(data[required[k]])) {
+      if (!empty(data[required[k]])) {
         return callback(new Error('Missing required field: ' + required[k]));
       }
     }
@@ -41,12 +41,12 @@ var createRecordByJSON = function(data, callback) {
   var required = ['from', 'form'],
       optional = ['reported_date', 'locale'];
   // check required fields are in _meta property
-  if (!exists(data._meta)) {
+  if (!empty(data._meta)) {
     return callback(new Error('Missing _meta property.'));
   }
   for (var k in required) {
     if (required.hasOwnProperty(k)) {
-      if (!exists(data._meta[required[k]])) {
+      if (!empty(data._meta[required[k]])) {
         return callback(new Error('Missing required field: ' + required[k]));
       }
     }

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,10 +23,6 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
-  if (!(message.from && message.content)) {
-    return callback(new Error('All SMS messages must contain a from and content field'));
-  }
-
   recordUtils.createByForm({
     from: message.from,
     message: message.content,

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,6 +23,10 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
+  if (!(message.from && message.content)) {
+    return callback(new Error('All SMS messages must contain a from and content field'));
+  }
+
   recordUtils.createByForm({
     from: message.from,
     message: message.content,
@@ -112,6 +116,8 @@ module.exports = {
       getOutgoing
     ], (err, [,,outgoingMessages]) => {
       if (err) {
+        console.error('There was an error processing the following SMS POST request');
+        console.error(JSON.stringify(req.body));
         return callback(err);
       }
       callback(null, { messages: outgoingMessages });

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -112,8 +112,6 @@ module.exports = {
       getOutgoing
     ], (err, [,,outgoingMessages]) => {
       if (err) {
-        console.error('There was an error processing the following SMS POST request');
-        console.error(JSON.stringify(req.body));
         return callback(err);
       }
       callback(null, { messages: outgoingMessages });

--- a/tests/unit/controllers/record-utils.js
+++ b/tests/unit/controllers/record-utils.js
@@ -21,13 +21,13 @@ exports['create form returns formated error from string'] = function(test) {
   });
 };
 
-exports['create form returns error if missing required field'] = function(test) {
+exports['create form returns error if form value is missing'] = function(test) {
   test.expect(2);
   var req = sinon.stub(db, 'request');
   controller.createByForm({
     message: 'test'
   }, function(err) {
-    test.equals(err.message, 'Missing required field: from');
+    test.equals(err.message, 'Missing required value: from');
     test.equals(req.callCount, 0);
     test.done();
   });


### PR DESCRIPTION
# Description

Allow for empty SMS messages

medic/medic-webapp#3658

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
