### PR TITLE
Don't throw errors for bad messages medic/medic-webapp#3672

### DIFF
--- a/controllers/messages.js
+++ b/controllers/messages.js
@@ -59,13 +59,13 @@ const applyTaskStateChangesToDocs = (taskStateChanges, docs) => {
 
   taskStateChanges.forEach(taskStateChange => {
     if (!taskStateChange.messageId) {
-      throw {code: 400, message: 'Message id required'};
+      return console.error('Message id required', taskStateChange);
     }
 
     const {task, docId} = getTaskAndDocForMessage(taskStateChange.messageId, docs);
 
     if (!task) {
-      throw {code: 404, message: `Message not found: ${taskStateChange.messageId}`};
+      return console.error(`Message not found: ${taskStateChange.messageId}`);
     }
 
     fillTaskStateChangeByDocId(taskStateChange, docId);
@@ -155,12 +155,7 @@ module.exports = {
       db.medic.fetch({keys: idsToFetch}, (err, docResults) => {
         const docs = _.pluck(docResults.rows, 'doc');
 
-        let stateChangesByDocId;
-        try {
-          stateChangesByDocId = applyTaskStateChangesToDocs(taskStateChanges, docs);
-        } catch (err) {
-          return callback(err);
-        }
+        const stateChangesByDocId = applyTaskStateChangesToDocs(taskStateChanges, docs);
 
         db.medic.bulk({docs: docs}, (err, results) => {
           if (err) {

--- a/tests/unit/controllers/messages.js
+++ b/tests/unit/controllers/messages.js
@@ -150,7 +150,7 @@ exports['updateMessageTaskStates takes a collection of state changes and saves i
   });
 };
 
-exports['updateMessageTaskStates throws an error if it cant find the message'] = test => {
+exports['updateMessageTaskStates DOES NOT throw an error if it cant find the message'] = test => {
   sinon.stub(db.medic, 'view').callsArgWith(3, null, {rows: [
     {id: 'testMessageId1'}]});
 
@@ -177,11 +177,9 @@ exports['updateMessageTaskStates throws an error if it cant find the message'] =
       state: 'testState2',
       details: 'Just because.'
     }
-  ], (err) => {
-    test.ok(err);
-
-    test.equal(err.code, 404);
-    test.equal(err.message, `Message not found: testMessageId2`);
+  ], (err, result) => {
+    test.equal(err, null);
+    test.deepEqual(result, {success: true});
 
     test.done();
   });


### PR DESCRIPTION
Instead of erroring simply log the problems and otherwise ignore the bad
data. We want to do this because we don't want to push problems back to
gateway, as gateway is hard to debug or even access, whereas api is in a
nice easy location to view logs and so on.

medic/medic-webapp#3672

# Review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [x] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [x] Webapp CI runs clean against this branch: https://github.com/medic/medic-webapp/pull/3673
