### PR TITLE
Silently fail to save sms without content or from fields

### DIFF
--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,13 +23,15 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
-  if(message.from && message.content){
-    recordUtils.createByForm({
-      from: message.from,
-      message: message.content,
-      gateway_ref: message.id,
-    }, callback);
+  if(!message.from || !message.content){
+    return callback();
   }
+
+  recordUtils.createByForm({
+    from: message.from,
+    message: message.content,
+    gateway_ref: message.id,
+  }, callback);
 }
 
 function mapStateFields(update) {

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,11 +23,13 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
-  recordUtils.createByForm({
-    from: message.from,
-    message: message.content,
-    gateway_ref: message.id,
-  }, callback);
+  if(message.from && message.content){
+    recordUtils.createByForm({
+      from: message.from,
+      message: message.content,
+      gateway_ref: message.id,
+    }, callback);
+  }
 }
 
 function mapStateFields(update) {

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,13 +23,9 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
-  if(!message.from || !message.content){
-    return callback();
-  }
-
   recordUtils.createByForm({
     from: message.from,
-    message: message.content,
+    message: message.content || '',
     gateway_ref: message.id,
   }, callback);
 }


### PR DESCRIPTION
# Description

Fixes this error: https://github.com/medic/medic-projects/issues/2480#issuecomment-317370396.
This PR is an extension to a change @SCdF made in this issue: medic/medic-webapp/issues/3672.  The error is logged as per the change by @SCdF, this PR just makes the saving silently fail if there are no `from` and `content` fields - this error is logged already by the changes that Stefan made in the other PR.

medic/medic-webapp#[3672]

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
