### PR TITLE
SMSs with empty from and content fields are still valid messages.  They should not be rejected by API.  If they are unexpected or unwanted, this should beBe more precise and permissive with SMS field requirements

### DIFF
--- a/controllers/record-utils.js
+++ b/controllers/record-utils.js
@@ -22,7 +22,8 @@ var request = function(opts, callback) {
 };
 
 var createByForm = function(data, callback) {
-  if (empty(data.from)) {
+  // We're OK with from being empty - sometimes weird things happen with SMS
+  if (!data.hasOwnProperty('from')) {
     return callback(new Error('Missing required value: from'));
   }
 

--- a/controllers/sms-gateway.js
+++ b/controllers/sms-gateway.js
@@ -23,7 +23,7 @@ const _ = require('underscore'),
 // See: https://github.com/medic/medic-webapp/issues/3019
 // Specifically, this should be in a new repo that we can pull in via npm
 function saveToDb(message, callback) {
-  if (!(message.from && message.content)) {
+  if (message.from === undefined || message.content === undefined) {
     return callback(new Error('All SMS messages must contain a from and content field'));
   }
 


### PR DESCRIPTION
SMSs with empty from and content fields are still valid messages.  They should not be rejected by API.  If they are unexpected or unwanted, API should discard them and log this at its discretion.

Also, the error thrown in `sms-gateway.saveToDb()` comes from a commit which appears on `2.12.x` branch, but not on `master`.  Is that deliberate, or should it (and this PR) be ported to `master`?