### PR TITLE
Replication key falls back to contact

### DIFF
--- a/handlers/changes.js
+++ b/handlers/changes.js
@@ -337,7 +337,7 @@ var getReplicationKey = function(doc) {
       doc.type === 'translations') {
     return [ '_all', {} ];
   }
-  var getSubject = function(doc) {
+  var getSubject = function() {
     if (doc.form) {
       // report
       if (doc.errors && doc.errors.length) {
@@ -369,7 +369,7 @@ var getReplicationKey = function(doc) {
   };
   switch (doc.type) {
     case 'data_record':
-      var subject = getSubject(doc);
+      var subject = getSubject();
       var value = {};
       if (doc.form && doc.contact) {
         value.submitter = doc.contact._id;

--- a/handlers/changes.js
+++ b/handlers/changes.js
@@ -337,32 +337,44 @@ var getReplicationKey = function(doc) {
       doc.type === 'translations') {
     return [ '_all', {} ];
   }
+  var getSubject = function(doc) {
+    if (doc.form) {
+      // report
+      if (doc.errors && doc.errors.length) {
+        for (var i = 0; i < doc.errors.length; i++) {
+          // no patient found, fall back to using contact. #3437
+          if (doc.errors[i].code === 'registration_not_found') {
+            return doc.contact && doc.contact._id;
+          }
+        }
+      }
+      return (doc.patient_id || (doc.fields && doc.fields.patient_id)) ||
+             (doc.place_id || (doc.fields && doc.fields.place_id)) ||
+             (doc.contact && doc.contact._id);
+    }
+    if (doc.sms_message) {
+      // incoming message
+      return doc.contact && doc.contact._id;
+    }
+    if (doc.kujua_message) {
+      // outgoing message
+      return doc.tasks &&
+             doc.tasks[0] &&
+             doc.tasks[0].messages &&
+             doc.tasks[0].messages[0] &&
+             doc.tasks[0].messages[0].contact &&
+             doc.tasks[0].messages[0].contact._id;
+    }
+    return '_unassigned';
+  };
   switch (doc.type) {
     case 'data_record':
-      var subject;
-      var submitter;
-      if (doc.form) {
-        // report
-        subject = (doc.patient_id || (doc.fields && doc.fields.patient_id)) ||
-                  (doc.place_id || (doc.fields && doc.fields.place_id)) ||
-                  (doc.contact && doc.contact._id);
-        submitter = doc.contact && doc.contact._id;
-      } else if (doc.sms_message) {
-        // incoming message
-        subject = doc.contact && doc.contact._id;
-      } else if (doc.kujua_message) {
-        // outgoing message
-        subject = doc.tasks &&
-                  doc.tasks[0] &&
-                  doc.tasks[0].messages &&
-                  doc.tasks[0].messages[0] &&
-                  doc.tasks[0].messages[0].contact &&
-                  doc.tasks[0].messages[0].contact._id;
+      var subject = getSubject(doc);
+      var value = {};
+      if (doc.form && doc.contact) {
+        value.submitter = doc.contact._id;
       }
-      if (subject) {
-        return [ subject, { submitter: submitter } ];
-      }
-      return [ '_unassigned', {} ];
+      return [ subject, value ];
     case 'clinic':
     case 'district_hospital':
     case 'health_center':


### PR DESCRIPTION
# Description

When we detect that the patient report references a patient but we
can't find them by the given ID the replication key falls back to
the contact ID. This means that restricted users that can
replicate the CHW can replicate the report.

This allows for the CHW and supervisors to see the report and
resubmit with the correct patient id.

medic/medic-webapp#3437

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
