### PR TITLE
Default null translation values to key

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -96,6 +96,11 @@ var getAttachment = function(name, callback) {
       if (err) {
         return callback(err);
       }
+      Object.keys(values).forEach(function(key) {
+        if (values[key] === null) {
+          values[key] = key;
+        }
+      });
       callback(null, {
         code: extractLocaleCode(name),
         values: values


### PR DESCRIPTION
# Description

If the messages-xy.properties file has an empty translation value
it will be parsed and stored in our messages-xy doc as null. When
rendering using the angular directive this will safely fall back to
rendering the key, however when translating with the $translate
service an error is thrown. This change sets the value in the
database to the key so the $translate service behaves consistently
with the angular directive.

medic/medic-webapp#3753

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
