### PR TITLE
Remove assumption of Object inheritance

### DIFF
--- a/controllers/record-utils.js
+++ b/controllers/record-utils.js
@@ -23,12 +23,12 @@ var request = function(opts, callback) {
 
 var createByForm = function(data, callback) {
   // We're OK with from being empty - sometimes weird things happen with SMS
-  if (!data.hasOwnProperty('from')) {
+  if (data.from === undefined) {
     return callback(new Error('Missing required value: from'));
   }
 
   // We're OK with message being empty, but the field should exist
-  if (!data.hasOwnProperty('message')) {
+  if (data.message === undefined) {
     return callback(new Error('Missing required field: message'));
   }
 

--- a/tests/unit/controllers/record-utils.js
+++ b/tests/unit/controllers/record-utils.js
@@ -21,6 +21,20 @@ exports['create form returns formated error from string'] = function(test) {
   });
 };
 
+// This asserts that we don't rely on any Object properties because req.body doesn't extend Object
+exports['create form handles weird pseudo object returned from req.body - #3770'] = function(test) {
+  sinon.stub(db, 'getPath').returns('dummy/path');
+  var req = sinon.stub(db, 'request').callsArgWith(1, null, { payload: { success: true, id: 5 }});
+  var body = Object.create(null);
+  body.message = 'test';
+  body.from = '+123';
+  controller.createByForm(body, function(err) {
+    test.equals(err, null);
+    test.equals(req.callCount, 1);
+    test.done();
+  });
+};
+
 exports['create form returns error if form value is missing'] = function(test) {
   test.expect(2);
   var req = sinon.stub(db, 'request');


### PR DESCRIPTION
# Description

The req.body doesn't inherit from Object so doesn't have the
hasOwnProperty function defined.

medic/medic-webapp#3770

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
