### PR TITLE
Ensure all languages have all keys

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -47,11 +47,22 @@ var createDoc = function(attachment) {
 
 var merge = function(attachments, backups, docs) {
   var updatedDocs = [];
+  var knownKeys = [];
+  var english = _.findWhere(attachments, { code: 'en' });
+  if (english) {
+    knownKeys = Object.keys(english.values);
+  }
   attachments.forEach(function(attachment) {
     var code = attachment.code;
     if (!code) {
       return;
     }
+    knownKeys.forEach(function(knownKey) {
+      var value = attachment.values[knownKey];
+      if (_.isUndefined(value) || value === null) {
+        attachment.values[knownKey] = knownKey;
+      }
+    });
     var backup = _.findWhere(backups, { code: code });
     if (!backup) {
       // new language
@@ -67,7 +78,7 @@ var merge = function(attachments, backups, docs) {
         var existing = doc.values[key];
         var backedUp = backup.values[key];
         var attached = attachment.values[key];
-        if (typeof existing === 'undefined' ||
+        if (_.isUndefined(existing) ||
             (existing === backedUp && backedUp !== attached)) {
           // new or updated translation
           doc.values[key] = attachment.values[key];
@@ -96,11 +107,6 @@ var getAttachment = function(name, callback) {
       if (err) {
         return callback(err);
       }
-      Object.keys(values).forEach(function(key) {
-        if (values[key] === null) {
-          values[key] = key;
-        }
-      });
       callback(null, {
         code: extractLocaleCode(name),
         values: values


### PR DESCRIPTION
# Description

Uses English as the canonical set of translation keys and ensures
that any languages that are shipped with an incomplete set are
updated to contain all known keys.

medic/medic-webapp#3753

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
