### PR TITLE
Gracefully handle errors from request lib

### DIFF
--- a/server-utils.js
+++ b/server-utils.js
@@ -54,7 +54,7 @@ module.exports = {
     if (code === 401) {
       return module.exports.notLoggedIn(req, res, showPrompt);
     }
-    if (code === 500) {
+    if (code >= 500 && code < 600) {
       return module.exports.serverError(err, req, res);
     }
     respond(req, res, code, err.message || err.reason);

--- a/tests/unit/server-utils.js
+++ b/tests/unit/server-utils.js
@@ -50,36 +50,11 @@ exports['error calls notLoggedIn when given 401 error'] = test => {
   test.done();
 };
 
-exports['error handles node errors'] = test => {
+exports['error function handles 503 errors - #3821'] = test => {
   test.expect(5);
   const writeHead = sinon.stub(res, 'writeHead');
   const end = sinon.stub(res, 'end');
-  serverUtils.error({ code: 503, message: 'some error' }, req, res);
-  test.equals(writeHead.callCount, 1);
-  test.equals(writeHead.args[0][0], 500);
-  test.equals(writeHead.args[0][1]['Content-Type'], 'text/plain');
-  test.equals(end.callCount, 1);
-  test.equals(end.args[0][0], 'Server error');
-  test.done();
-};
-
-exports['error handles nano errors'] = test => {
-  test.expect(5);
-  const writeHead = sinon.stub(res, 'writeHead');
-  const end = sinon.stub(res, 'end');
-  serverUtils.error({ statusCode: 503, reason: 'some error' }, req, res);
-  test.equals(writeHead.callCount, 1);
-  test.equals(writeHead.args[0][0], 500);
-  test.equals(writeHead.args[0][1]['Content-Type'], 'text/plain');
-  test.equals(end.callCount, 1);
-  test.equals(end.args[0][0], 'Server error');
-  test.done();
-};
-
-exports['error handles request errors - #3821'] = test => {
-  test.expect(5);
-  const writeHead = sinon.stub(res, 'writeHead');
-  const end = sinon.stub(res, 'end');
+  // an example error thrown by the `request` library
   const error = {
     code: 503,
     message: {


### PR DESCRIPTION
# Description

This improves our error handling so errors being thrown from the
request library do not crash API. From now on any 5xx error is to
be treated as a server error.

medic/medic-webapp#3821

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
