### PR TITLE
Store sentinel meta-data in a _local document

### DIFF
--- a/migrations/move-sentinel-metadata.js
+++ b/migrations/move-sentinel-metadata.js
@@ -1,0 +1,28 @@
+const db = require('../db');
+
+module.exports = {
+  name: 'move-sentinel-metadata',
+  created: new Date(2017, 09, 01, 16, 25, 54),
+  run: function(callback) {
+    db.medic.get('sentinel-meta-data', (err, doc) => {
+      if (err && err.statusCode !== 404) {
+        return callback(err);
+      }
+
+      if (doc) {
+        const { _id, _rev } = doc;
+
+        doc._id = '_local/sentinel-meta-data';
+        delete doc._rev;
+
+        db.medic.insert(doc, err => {
+          if (err) {
+            return callback(err);
+          }
+
+          db.medic.destroy(_id, _rev, callback);
+        });
+      }
+    });
+  }
+};

--- a/migrations/move-sentinel-metadata.js
+++ b/migrations/move-sentinel-metadata.js
@@ -22,6 +22,8 @@ module.exports = {
 
           db.medic.destroy(_id, _rev, callback);
         });
+      } else {
+        callback();
       }
     });
   }


### PR DESCRIPTION
This document stores sequence numbers, and so is only relevant on the
specific instance it was created on. Replicating it to another instance
will cause sentinel to behave incorrectly.

medic/medic-webapp#3860

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
