### PR TITLE
Make more errors more public

### DIFF
--- a/controllers/record-utils.js
+++ b/controllers/record-utils.js
@@ -25,7 +25,7 @@ var request = function(opts, callback) {
 var createByForm = function(data, callback) {
   // We're OK with from being empty - sometimes weird things happen with SMS
   if (data.from === undefined) {
-    return callback(new Error('Missing required value: from'));
+    return callback(new PublicError('Missing required value: from'));
   }
 
   // We're OK with message being empty, but the field should exist
@@ -48,7 +48,7 @@ var createRecordByJSON = function(data, callback) {
       optional = ['reported_date', 'locale'];
   // check required fields are in _meta property
   if (empty(data._meta)) {
-    return callback(new Error('Missing _meta property.'));
+    return callback(new PublicError('Missing _meta property.'));
   }
   for (var k of required) {
     if (empty(data._meta[k])) {

--- a/server.js
+++ b/server.js
@@ -440,7 +440,7 @@ app.post('/api/v1/records', [jsonParser, formParser], function(req, res) {
     }
     records.create(req.body, req.is(['json','urlencoded']), function(err, result) {
       if (err) {
-        return serverUtils.serverError(err.message, req, res);
+        return serverUtils.serverError(err, req, res);
       }
       res.json(result);
     });


### PR DESCRIPTION
There were a couple of reasons why the specific error from the original issue was not being made public:
1. that specific example was not being made a `PublicError` instance instead of a standard `Error`
2. calls to `server-utils.serverError()` regularly pass `err.message` as the first argument.  Changing this to `err` is much more useful.  I can't see any obvious problem with changing it, except that logging will start to include stacktraces.  E.g.
```
15:20:20 api.1    | Server error: Missing required value: from
```
would become:
```
15:20:20 api.1    | Server error:
15:20:20 api.1    |  { Error: Missing required value: from
15:20:20 api.1    |     at Object.createByForm (/Users/user/workspaces/medic/api/controllers/record-utils.js:28:21)
15:20:20 api.1    |     at Object.create (/Users/user/workspaces/medic/api/controllers/records.js:6:26)
15:20:20 api.1    |     at /Users/user/workspaces/medic/api/server.js:441:13
15:20:20 api.1    |     at /Users/user/workspaces/medic/api/auth.js:115:16
15:20:20 api.1    |     at /Users/user/workspaces/medic/api/auth.js:87:16
15:20:20 api.1    |     at Request._callback (/Users/user/workspaces/medic/api/auth.js:19:5)
15:20:20 api.1    |     at Request.self.callback (/Users/user/workspaces/medic/api/node_modules/request/request.js:188:22)
15:20:20 api.1    |     at emitTwo (events.js:125:13)
15:20:20 api.1    |     at Request.emit (events.js:213:7)
15:20:20 api.1    |     at Request.<anonymous> (/Users/user/workspaces/medic/api/node_modules/request/request.js:1171:10) publicMessage: 'Missing required value: from' }
```

Some options to reduce this logging, if desired:
* more complex code in `serverError` could be added to check the type of the argument, and log `err.message` instead of `err` if it's an `Error`
* calls could pass `Error` instances instead of `String`s


Issue medic/medic-webapp#2994