### PR TITLE
Lock down the version of nano

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lucene-query-generator": "^0.2.0",
     "moment": "^2.10.6",
     "morgan": "^1.6.1",
-    "nano": "^6.4.0",
+    "nano": "6.4.0",
     "object-path": "^0.11.1",
     "openrosa-formlist": "github:medic/openrosa-formlist#sax",
     "pass-stream": "^1.0.0",


### PR DESCRIPTION
# Description

Specify the 6.4.0 version of nano in the package.json so older
versions of node which don't support the package-lock.json don't
get 6.4.2 which throws a runtime error.

medic/medic-webapp#3963

# Review checklist

- [ ] Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- [ ] Documented: Announced in Changes.md in plain English. Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.
- [ ] Webapp CI runs clean against this branch
